### PR TITLE
fix compilation when including bse header for out-of-tree code

### DIFF
--- a/bse/bsecategories.hh
+++ b/bse/bsecategories.hh
@@ -10,7 +10,7 @@
 typedef gboolean (BseCategoryCheck) (const Bse::Category *category, void *data);
 
 /* --- prototypes --- */
-void             bse_categories_register              (const std::string &category, const char *i18n_category, GType type, const uint8 *pixstream);
+void             bse_categories_register              (const std::string &category, const char *i18n_category, GType type, const Bse::uint8 *pixstream);
 Bse::CategorySeq bse_categories_match                 (const std::string &pattern, GType base_type, BseCategoryCheck check, void *data);
 Bse::CategorySeq bse_categories_match_typed           (const std::string &pattern, GType base_type);
 Bse::CategorySeq bse_categories_from_type             (GType type);

--- a/bse/bseexports.hh
+++ b/bse/bseexports.hh
@@ -103,7 +103,7 @@ typedef struct {
 typedef struct {
   uint           major, minor, micro;
   uint           dummy1, dummy2, dummy3, dummy4, dummy5;
-  uint64         export_flags;
+  Bse::uint64    export_flags;
   BseExportNode *export_chain;
 } BseExportIdentity;
 #define BSE_EXPORT_IDENTITY(HEAD)                               \

--- a/bse/bsemididecoder.hh
+++ b/bse/bsemididecoder.hh
@@ -26,14 +26,14 @@ struct BseMidiDecoder {
   /*< private >*/
   uint                 state_changed : 1;
   BseMidiDecoderState  state;
-  uint32               delta_time;     /* valid after BSE_MIDI_DECODER_DELTA_TIME_LOW */
+  Bse::uint32          delta_time;     /* valid after BSE_MIDI_DECODER_DELTA_TIME_LOW */
   BseMidiEventType     event_type;     /* event after BSE_MIDI_DECODER_META_EVENT */
   BseMidiEventType     running_mode;
   uint                 zchannel;       /* current channel prefix (offset=-1) */
-  uint32               left_bytes;     /* data to be read (BSE_MIDI_DECODER_DATA) */
+  Bse::uint32          left_bytes;     /* data to be read (BSE_MIDI_DECODER_DATA) */
   /* data accu */
   uint                 n_bytes;
-  uint8               *bytes;
+  Bse::uint8          *bytes;
 };
 
 
@@ -44,11 +44,11 @@ BseMidiDecoder* bse_midi_decoder_new                      (gboolean             
 void            bse_midi_decoder_destroy                  (BseMidiDecoder       *self);
 void            bse_midi_decoder_push_data                (BseMidiDecoder       *self,
                                                            uint                  n_bytes,
-                                                           uint8                *bytes,
-                                                           uint64                usec_systime);
+                                                           Bse::uint8           *bytes,
+                                                           Bse::uint64           usec_systime);
 void            bse_midi_decoder_push_smf_data            (BseMidiDecoder       *self,
                                                            uint                  n_bytes,
-                                                           uint8                *bytes);
+                                                           Bse::uint8           *bytes);
 BseMidiEvent*   bse_midi_decoder_pop_event                (BseMidiDecoder       *self);
 SfiRing*        bse_midi_decoder_pop_event_list           (BseMidiDecoder       *self);
 

--- a/bse/bsemidievent.hh
+++ b/bse/bsemidievent.hh
@@ -124,14 +124,14 @@ BseMidiEvent* bse_midi_alloc_event    (void);
 BseMidiEvent* bse_midi_copy_event     (const BseMidiEvent *src);
 void          bse_midi_free_event     (BseMidiEvent       *event);
 BseMidiEvent* bse_midi_event_note_on  (uint                midi_channel,
-                                       uint64              delta_time,
+                                       Bse::uint64         delta_time,
                                        float               frequency,
                                        float               velocity);
 BseMidiEvent* bse_midi_event_note_off (uint                midi_channel,
-                                       uint64              delta_time,
+                                       Bse::uint64         delta_time,
                                        gfloat              frequency);
 BseMidiEvent* bse_midi_event_signal   (uint                midi_channel,
-                                       uint64              delta_time,
+                                       Bse::uint64         delta_time,
                                        Bse::MidiSignal   signal_type,
                                        float               value);
 double        bse_midi_signal_default (Bse::MidiSignal signal);

--- a/bse/bsepcmwriter.hh
+++ b/bse/bsepcmwriter.hh
@@ -19,19 +19,19 @@ struct BsePcmWriter : BseItem {
   guint		open : 1;
   guint		broken : 1;
   gint		fd;
-  uint64	n_bytes;
-  uint64        recorded_maximum;
-  uint64        start_tick;
+  Bse::uint64	n_bytes;
+  Bse::uint64   recorded_maximum;
+  Bse::uint64   start_tick;
 };
 struct BsePcmWriterClass : BseItemClass
 {};
 
 Bse::Error bse_pcm_writer_open	(BsePcmWriter *pdev, const gchar *file, guint n_channels,
-                                 guint sample_freq, uint64 recorded_maximum);
+                                 guint sample_freq, Bse::uint64 recorded_maximum);
 void	   bse_pcm_writer_close	(BsePcmWriter *pdev);
 /* writing is lock protected */
 void	   bse_pcm_writer_write	(BsePcmWriter *pdev, size_t n_values,
-                                 const float *values, uint64 start_stamp);
+                                 const float *values, Bse::uint64 start_stamp);
 
 namespace Bse {
 

--- a/bse/bseutils.hh
+++ b/bse/bseutils.hh
@@ -42,7 +42,7 @@ void    bse_balance_set         (double  balance,
 
 
 /* --- icons --- */
-Bse::Icon bse_icon_from_pixstream (const uint8 *pixstream);
+Bse::Icon bse_icon_from_pixstream (const Bse::uint8 *pixstream);
 
 
 /* --- ID allocator --- */


### PR DESCRIPTION
Here is a pull request which fixes
https://github.com/tim-janik/beast/issues/3

Its the same code I sent to the mailing list before.