### PR TITLE
Test out oneline

### DIFF
--- a/bse/bseresamplerimpl.hh
+++ b/bse/bseresamplerimpl.hh
@@ -200,8 +200,6 @@ fir_test_filter_sse (bool        verbose,
     }
   if (errors)
     printf ("*** %d errors detected\n", errors);
-  else
-    printf ("filter implementation ok.\n");
 
   return (errors == 0);
 }


### PR DESCRIPTION
This should be uncontroversial: it makes bsefcompare|testresampler just output one single line:
```
  PASS...
  FAIL...
```
for the tests that are called from make, in order to get less cluttered build output.

If merge are done merging this branch, and also want all commits from resampler-test-fix branch, let me know if I should rebase these for you, as both branches contain changes for testresampler.