### PR TITLE
BSE: bse_cast - an API suggestion of how to handle bse object casts

### DIFF
--- a/bse/bseobject.hh
+++ b/bse/bseobject.hh
@@ -57,6 +57,7 @@ typedef enum				/*< skip >*/
 #define BSE_OBJECT_FLAGS_MAX_SHIFT  (16)
 
 /* --- typedefs & structures --- */
+
 struct BseObject : GObject {
   Bse::ObjectImpl       *cxxobject_;
   Bse::ObjectImplP      *cxxobjref_; // shared_ptr that keeps a reference on cxxobject_ until dispose()
@@ -87,6 +88,15 @@ struct BseObject : GObject {
     return impl ? Bse::shared_ptr_cast<ObjectImplT> (impl) : NULL;
   }
 };
+
+template<class ObjectImplP>
+ObjectImplP bse_cast (BseObject *object)
+{
+  if (object)
+    return object->as<ObjectImplP>();
+  else
+    return nullptr;
+}
 
 struct BseObjectClass : GObjectClass {
   gboolean              (*editable_property)    (BseObject      *object, /* for set_property/get_property implementations */

--- a/bse/bsesong.cc
+++ b/bse/bsesong.cc
@@ -776,7 +776,7 @@ SongImpl::find_any_track_for_part (PartIface &part)
   assert_return (dynamic_cast<ItemImpl*> (&part)->parent() == this, NULL);
   BsePart *bpart = part.as<BsePart*>();
   BseTrack *track = bse_song_find_first_track (self, bpart);
-  return track ? track->as<TrackIfaceP> () : NULL;
+  return bse_cast<TrackIfaceP> (track);
 }
 
 BusIfaceP
@@ -987,7 +987,7 @@ SongImpl::find_track_for_part (PartIface &part_iface)
 	  tick = start;
 	}
     }
-  return track ? track->as<TrackIfaceP>() : NULL;
+  return bse_cast<TrackIfaceP> (track);
 }
 
 BusIfaceP

--- a/bse/bsetrack.cc
+++ b/bse/bsetrack.cc
@@ -1243,7 +1243,7 @@ TrackImpl::get_part (int tick)
 {
   BseTrack *self = as<BseTrack*>();
   BseTrackEntry *entry = bse_track_lookup_tick (self, tick);
-  return entry ? entry->part->as<PartIfaceP>() : NULL;
+  return bse_cast<PartIfaceP> (entry->part);
 }
 
 int


### PR DESCRIPTION
During fixes for https://github.com/tim-janik/beast/issues/32 https://github.com/tim-janik/beast/issues/24 you introduced manual null pointer checks for `as<TrackIfaceP>` and so on. I don't believe that this is the best approach; so I here is a suggestion of how I think it should be done.

I would recommend replacing each invocation of `as<>` with `bse_cast<>`, even if in some cases this will be a little longer:
```
casting track object
old: track ? track->as<TrackIfaceP>() : NULL;
new: bse_cast<TrackIfaceP> (track);

casting this object
old: as<TrackIfaceP>();
new: bse_cast<TrackIfaceP> (this);
```
However, I still think my version is the better API, because
- you cannot forget the null pointer check by accident
- it is a little more intuitive to see that we're just casting here

Its a bit of work to do the details and replace all cases where this is used, but if you want to go this way, I can provide a complete patch which eliminates as<>() completely.