### PR TITLE
Port property Song::loop_enabled to C++

### DIFF
--- a/beast-gtk/bsttrackview.cc
+++ b/beast-gtk/bsttrackview.cc
@@ -690,9 +690,8 @@ track_view_set_container (BstItemView *iview,
       bse_proxy_disconnect (self->song.proxy_id(),
                             "any_signal", track_view_pointer_changed, self,
                             "any_signal", track_view_marks_changed, self,
-                            "any_signal", track_view_repeat_changed, self,
                             NULL);
-      self->song = NULL; /* disconnect */
+      self->song = NULL; // disconnects event handlers
     }
   BST_ITEM_VIEW_CLASS (bst_track_view_parent_class)->set_container (iview, new_container);
   if (self->troll)

--- a/beast-gtk/bsttrackview.cc
+++ b/beast-gtk/bsttrackview.cc
@@ -510,7 +510,7 @@ static void
 track_view_repeat_toggled (BstTrackView *self)
 {
   if (self->song && self->repeat_toggle)
-    bse_proxy_set (self->song.proxy_id(), "loop_enabled", GTK_TOGGLE_BUTTON (self->repeat_toggle)->active, NULL);
+    self->song.loop_enabled (GTK_TOGGLE_BUTTON (self->repeat_toggle)->active);
 }
 
 static void
@@ -519,8 +519,7 @@ track_view_repeat_changed (BstTrackView *self)
   if (self->song && self->repeat_toggle)
     {
       GtkToggleButton *toggle = GTK_TOGGLE_BUTTON (self->repeat_toggle);
-      gboolean enabled;
-      bse_proxy_get (self->song.proxy_id(), "loop_enabled", &enabled, NULL);
+      gboolean enabled = self->song.loop_enabled();
       if (toggle->active != enabled)
 	gtk_toggle_button_set_active (toggle, enabled);
     }
@@ -707,12 +706,12 @@ track_view_set_container (BstItemView *iview,
   if (self->song)
     {
       bst_track_roll_controller_set_song (self->tctrl, self->song.proxy_id());
+      self->song.on ("notify:loop_enabled", [self]() { track_view_repeat_changed (self); });
       bse_proxy_connect (self->song.proxy_id(),
 			 "swapped_signal::pointer-changed", track_view_pointer_changed, self,
 			 "swapped_signal::property-notify::loop-left", track_view_marks_changed, self,
 			 "swapped_signal::property-notify::loop-right", track_view_marks_changed, self,
 			 "swapped_signal::property-notify::tick-pointer", track_view_marks_changed, self,
-			 "swapped_signal::property-notify::loop-enabled", track_view_repeat_changed, self,
 			 NULL);
       track_view_marks_changed (self);
       track_view_repeat_changed (self);

--- a/beast-gtk/bsttrackview.hh
+++ b/beast-gtk/bsttrackview.hh
@@ -21,6 +21,7 @@ typedef	struct	_BstTrackViewClass BstTrackViewClass;
 struct _BstTrackView
 {
   BstItemView	          parent_object;
+  Bse::SongS              song;
   BstTrackRoll	         *troll;
   BstTrackRollController *tctrl;
   GtkWidget		 *repeat_toggle;

--- a/bse/bseapi.idl
+++ b/bse/bseapi.idl
@@ -1031,6 +1031,9 @@ interface Song : SNet {
                                            "tuning system defines the number and spacing of frequency values applied."),
                                          STANDARD  ":unprepared");
   };
+  group _("Looping") {
+    bool loop_enabled = Bool (_("Loop Enabled"), "", STORAGE ":skip-default:skip-undo", false);
+  };
 };
 
 ///< Structure containing meta data for multi wave samples.

--- a/bse/bsesong.hh
+++ b/bse/bsesong.hh
@@ -74,8 +74,10 @@ public:
   explicit                  SongImpl                (BseObject*);
   virtual double            bpm                     () const override;
   virtual void              bpm                     (double val) override;
-  virtual MusicalTuning musical_tuning          () const override;
+  virtual MusicalTuning     musical_tuning          () const override;
   virtual void              musical_tuning          (MusicalTuning tuning) override;
+  virtual bool              loop_enabled            () const override;
+  virtual void              loop_enabled            (bool enabled) override;
   virtual SongTiming        get_timing              (int tick);
   virtual TrackIfaceP       find_any_track_for_part (PartIface &part) override;
   virtual BusIfaceP         create_bus              () override;


### PR DESCRIPTION
Please merge. I ported and tested this property port.

Remarks: I tried and failed to use something like (doesn't compile).
```
bool loop_enabled = Bool (... STORAGE SKIP_DEFAULT SKIP_UNDO ...)
```
Everything works as it is, but this would catch typos. In any case, it is not a big problem.