### PR TITLE
More Song properties C++ified

### DIFF
--- a/bse/bseapi.idl
+++ b/bse/bseapi.idl
@@ -1013,7 +1013,6 @@ interface Song : SNet {
   // signal void   pointer_changed (int32 a);
   // group _("Timing") {
   // int32   tpqn          = Range  ("Ticks", "Number of ticks per quarter note", STANDARD, 384, 384, 0, 384);
-  // int32   numerator     = Range  ("Numerator", "Measure numerator", STANDARD, 1, 256, 1, 4);
   // int32   denominator   = Range  ("Denominator", "Measure denominator, must be a power of 2", STANDARD, 1, 256, 1, 4);
   // float64 bpm           = Range  ("BPM", "Beats per minute", STANDARD, MIN_BPM, MAX_BPM, 10, 120);
   // };
@@ -1021,7 +1020,8 @@ interface Song : SNet {
   // CSynth  pnet          = Object ("Postprocessor", "Synthesis network to be used as postprocessor", STANDARD);
   // };
   group _("Timing") {
-    float64 bpm           = Range  (_("BPM"), _("Beats per minute"), STANDARD  ":scale", MIN_BPM, MAX_BPM, 10, 120);
+    int32   numerator     = Range (_("Numerator"), _("Measure numerator"), STANDARD, 1, 256, 1, 4);
+    float64 bpm           = Range (_("BPM"), _("Beats per minute"), STANDARD  ":scale", MIN_BPM, MAX_BPM, 10, 120);
   };
   group _("Tuning") {
     MusicalTuning musical_tuning = Enum (_("Musical Tuning"),

--- a/bse/bseapi.idl
+++ b/bse/bseapi.idl
@@ -1021,6 +1021,7 @@ interface Song : SNet {
   // };
   group _("Timing") {
     int32   numerator     = Range (_("Numerator"), _("Measure numerator"), STANDARD, 1, 256, 1, 4);
+    int32   denominator   = Range (_("Denominator"), _("Measure denominator, must be a power of 2"), STANDARD, 1, 256, 0, 4);
     float64 bpm           = Range (_("BPM"), _("Beats per minute"), STANDARD  ":scale", MIN_BPM, MAX_BPM, 10, 120);
   };
   group _("Tuning") {

--- a/bse/bseapi.idl
+++ b/bse/bseapi.idl
@@ -532,30 +532,31 @@ enum MonitorField {
 };
 
 // == Bse Constants ==
-Const MIN_NOTE      = 0;
-Const MAX_NOTE      = 131;          // 123
-Const NOTE_VOID     = MAX_NOTE + 1; /// Value represents unparsable/unknown notes
-Const KAMMER_NOTE   = 69;           /// Kammer note, representing the kammer frequency's MIDI note value for A' or A4
-Const KAMMER_FREQ   = 440.0;        /// Pitch Standard, see also: https://en.wikipedia.org/wiki/A440_(pitch_standard)
-Const KAMMER_OCTAVE = +1;           /// Octave number for MIDI A'
-Const MIN_OCTAVE    = -4;           /// Octave of MIN_NOTE
-Const MAX_OCTAVE    = +6;           /// Octave of MAX_NOTE
-Const MIN_FINE_TUNE = -100;
-Const MAX_FINE_TUNE = 100;
-Const MIN_BPM       = 1;
-Const MAX_BPM       = 1024;
-Const MIN_TRANSPOSE = -72;
-Const MAX_TRANSPOSE = +72;
-Const READWRITE     = "r:w:";
-Const GUI           = "r:w:G";
-Const STORAGE       = "r:w:S";
-Const STANDARD      = STORAGE ":G";
-Const NOTEHINTS     = STANDARD ":note";
-Const FINETUNEHINTS = STANDARD ":finetune";
-Const VELOCITYHINTS = STANDARD ":velocity";
+Const MIN_NOTE        = 0;
+Const MAX_NOTE        = 131;          // 123
+Const NOTE_VOID       = MAX_NOTE + 1; /// Value represents unparsable/unknown notes
+Const KAMMER_NOTE     = 69;           /// Kammer note, representing the kammer frequency's MIDI note value for A' or A4
+Const KAMMER_FREQ     = 440.0;        /// Pitch Standard, see also: https://en.wikipedia.org/wiki/A440_(pitch_standard)
+Const KAMMER_OCTAVE   = +1;           /// Octave number for MIDI A'
+Const MIN_OCTAVE      = -4;           /// Octave of MIN_NOTE
+Const MAX_OCTAVE      = +6;           /// Octave of MAX_NOTE
+Const MIN_FINE_TUNE   = -100;
+Const MAX_FINE_TUNE   = 100;
+Const MIN_BPM         = 1;
+Const MAX_BPM         = 1024;
+Const MIN_TRANSPOSE   = -72;
+Const MAX_TRANSPOSE   = +72;
+Const READWRITE       = "r:w:";
+Const GUI             = "r:w:G";
+Const STORAGE         = "r:w:S";
+Const STANDARD        = STORAGE ":G";
+Const STANDARD_RDONLY = STANDARD ":ro:";
+Const NOTEHINTS       = STANDARD ":note";
+Const FINETUNEHINTS   = STANDARD ":finetune";
+Const VELOCITYHINTS   = STANDARD ":velocity";
 /* extra options */
-Const SKIP_DEFAULT  = ":skip-default:";
-Const SKIP_UNDO     = ":skip-undo:";
+Const SKIP_DEFAULT    = ":skip-default:";
+Const SKIP_UNDO       = ":skip-undo:";
 
 /// Stringeq - a variable length list of test strings.
 sequence StringSeq {
@@ -1011,15 +1012,11 @@ interface Song : SNet {
   /// Synthesize a note on a song of an active project.
   void       synthesize_note         (Track track, int32 duration, int32 note, int32 fine_tune, float64 velocity);
   // signal void   pointer_changed (int32 a);
-  // group _("Timing") {
-  // int32   tpqn          = Range  ("Ticks", "Number of ticks per quarter note", STANDARD, 384, 384, 0, 384);
-  // int32   denominator   = Range  ("Denominator", "Measure denominator, must be a power of 2", STANDARD, 1, 256, 1, 4);
-  // float64 bpm           = Range  ("BPM", "Beats per minute", STANDARD, MIN_BPM, MAX_BPM, 10, 120);
-  // };
   // group _("MIDI Instrument") {
   // CSynth  pnet          = Object ("Postprocessor", "Synthesis network to be used as postprocessor", STANDARD);
   // };
   group _("Timing") {
+    int32   tpqn          = Range (_("TPQN"), _("Number of ticks per quarter note"), STANDARD_RDONLY, 384, 384, 0, 384);
     int32   numerator     = Range (_("Numerator"), _("Measure numerator"), STANDARD, 1, 256, 1, 4);
     int32   denominator   = Range (_("Denominator"), _("Measure denominator, must be a power of 2"), STANDARD, 1, 256, 0, 4);
     float64 bpm           = Range (_("BPM"), _("Beats per minute"), STANDARD  ":scale", MIN_BPM, MAX_BPM, 10, 120);

--- a/bse/bsesong.cc
+++ b/bse/bsesong.cc
@@ -989,7 +989,7 @@ SongImpl::tick_pointer (int tick)
       for (SfiRing *ring = self->tracks_SL; ring; ring = sfi_ring_walk (ring, self->tracks_SL))
         {
           BseTrack *track = (BseTrack*) ring->data;
-          track->track_done_SL = FALSE;	/* let sequencer recheck if playing */
+          track->track_done_SL = false;	/* let sequencer recheck if playing */
         }
       BSE_SEQUENCER_UNLOCK ();
 

--- a/bse/bsesong.cc
+++ b/bse/bsesong.cc
@@ -20,7 +20,6 @@
 enum
 {
   PROP_0,
-  PROP_TPQN,
   PROP_PNET,
 };
 
@@ -159,10 +158,6 @@ bse_song_set_property (GObject      *object,
                           NULL);
         }
       break;
-    case PROP_TPQN:
-      self->tpqn = sfi_value_get_int (value);
-      bse_song_update_tpsi_SL (self);
-      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, param_id, pspec);
       break;
@@ -180,9 +175,6 @@ bse_song_get_property (GObject     *object,
     {
     case PROP_PNET:
       bse_value_set_object (value, self->pnet);
-      break;
-    case PROP_TPQN:
-      sfi_value_set_int (value, self->tpqn);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, param_id, pspec);
@@ -613,10 +605,6 @@ bse_song_class_init (BseSongClass *klass)
 
   bse_song_timing_get_default (&timing);
 
-  bse_object_class_add_param (object_class, _("Timing"),
-			      PROP_TPQN,
-			      sfi_pspec_int ("tpqn", _("Ticks"), _("Number of ticks per quarter note"),
-					     timing.tpqn, 384, 384, 0, SFI_PARAM_STANDARD_RDONLY));
   bse_object_class_add_param (object_class, _("MIDI Instrument"),
                               PROP_PNET,
                               bse_param_spec_object ("pnet", _("Postprocessor"), _("Synthesis network to be used as postprocessor"),
@@ -869,6 +857,30 @@ SongImpl::bpm (double val)
       push_property_undo (prop);
       self->bpm = val;
       bse_song_update_tpsi_SL (self);
+      notify (prop);
+    }
+}
+
+
+int
+SongImpl::tpqn() const
+{
+  BseSong *self = const_cast<SongImpl*> (this)->as<BseSong*>();
+  return self->tpqn;
+}
+
+void
+SongImpl::tpqn (int val)
+{
+  BseSong *self = as<BseSong*>();
+  if (int (self->tpqn) != val)
+    {
+      const char *prop = "tpqn";
+      push_property_undo (prop);
+
+      self->tpqn = val;
+      bse_song_update_tpsi_SL (self);
+
       notify (prop);
     }
 }

--- a/bse/bsesong.hh
+++ b/bse/bsesong.hh
@@ -78,6 +78,8 @@ public:
   virtual void              denominator             (int val) override;
   virtual double            bpm                     () const override;
   virtual void              bpm                     (double val) override;
+  virtual int               tpqn                    () const override;
+  virtual void              tpqn                    (int val) override;
   virtual MusicalTuning     musical_tuning          () const override;
   virtual void              musical_tuning          (MusicalTuning tuning) override;
   virtual bool              loop_enabled            () const override;

--- a/bse/bsesong.hh
+++ b/bse/bsesong.hh
@@ -74,6 +74,8 @@ public:
   explicit                  SongImpl                (BseObject*);
   virtual int               numerator               () const override;
   virtual void              numerator               (int val) override;
+  virtual int               denominator             () const override;
+  virtual void              denominator             (int val) override;
   virtual double            bpm                     () const override;
   virtual void              bpm                     (double val) override;
   virtual MusicalTuning     musical_tuning          () const override;

--- a/bse/bsesong.hh
+++ b/bse/bsesong.hh
@@ -72,6 +72,8 @@ protected:
   virtual                  ~SongImpl                ();
 public:
   explicit                  SongImpl                (BseObject*);
+  virtual int               numerator               () const override;
+  virtual void              numerator               (int val) override;
   virtual double            bpm                     () const override;
   virtual void              bpm                     (double val) override;
   virtual MusicalTuning     musical_tuning          () const override;


### PR DESCRIPTION
Here is a C++ port for Song: tpqn / numerator / denominator

I renamed tpqn so that it says "TPQN" and not "Ticks" at the UI, because I think "Ticks" is a terrible name for that property, as it doesn't say what kind of ticks we have here.

I added STANDARD_RDONLY - we could also call this STANDARD RDONLY or STANDARD READONLY - I choose the name that SFI_* originally used.

I had to remove the computed defaults, since idl doesn't allow me to compute the default of a property. Previously the default values for properties were set in the Song implementation, so that the property defaults for bpm/numerator/... would always match the defaults from bse_song_timing_get_default().

However I think for Song, duplicating the defaults in bse_song_timing_get_default() and bseapi.idl is okay, because these probably will not change (often). One alternative would be to somehow allow the Song implementation to read the defaults that bseapi.idl defines, and so get rid of the duplication and make the idl file the canonic place.


The only Song property that remains is the post processing network, but since this has the type object, I am not able to port it now. If you have any preference for the next object properties to port, let me know.