### PR TITLE
Remove Rapicorn requirement from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,10 @@ synthesis threads and then immediately drops privileges.
 For Linux kernels of the 2.6.x series and later, this enables the
 low-latency scheduling behavior needed to avoid audio artefacts.
 
-In order to build release tarballs, `Rapicorn`, `GnomeCanvas`,
-`Ogg/Vorbis`, `libflac` and `npm` are required.
-Support for MP3 files is optional and requires `libmad` (MPEG audio
-decoder library) when compiling Beast.
-Compilation requires `g++-5.2.1` or later and a recent Linux
+In order to build release tarballs, `GnomeCanvas`, `Ogg/Vorbis`,
+`libflac` and `npm` are required.  Support for MP3 files is optional
+and requires `libmad` (MPEG audio decoder library) when compiling
+Beast.  Compilation requires `g++-5.2.1` or later and a recent Linux
 distribution like Ubuntu-14.04.
 
 


### PR DESCRIPTION
As per https://github.com/tim-janik/rapicorn/issues/14#issuecomment-416402264 beast no longer needs rapicorn.