### PR TITLE
Most Bus properties ported to C++

### DIFF
--- a/beast-gtk/bstbuseditor.cc
+++ b/beast-gtk/bstbuseditor.cc
@@ -157,19 +157,18 @@ bst_bus_editor_set_bus (BstBusEditor *self,
                          "signal::release", bus_editor_release_item, self,
                          NULL);
       /* create and hook up volume params & scopes */
-      GxkParam *lvolume = get_property_param (self, "left_volume");
-      GtkWidget *lspinner = gxk_param_create_editor (lvolume, "spinner");
-      GxkParam *rvolume = get_property_param (self, "right_volume");
-      GtkWidget *rspinner = gxk_param_create_editor (rvolume, "spinner");
+      GxkParam *volume_db = get_property_param (self, "volume_db");
+      GtkWidget *vspinner = gxk_param_create_editor (volume_db, "spinner");
+      GxkParam *pan = get_property_param (self, "pan");
+      GtkWidget *pspinner = gxk_param_create_editor (pan, "spinner");
+      GtkWidget *panscale = gxk_param_create_editor (pan, "hscale-lin");
+      g_signal_connect_object (panscale, "button-press-event", G_CALLBACK (grab_focus_and_false), pspinner, G_CONNECT_SWAPPED);
       BstDBMeter *dbmeter = (BstDBMeter*) gxk_radget_find (self, "db-meter");
       if (dbmeter)
         {
           GtkRange *range = bst_db_meter_get_scale (dbmeter, 0);
-          bst_db_scale_hook_up_param (range, lvolume);
-          g_signal_connect_object (range, "button-press-event", G_CALLBACK (grab_focus_and_false), lspinner, G_CONNECT_SWAPPED);
-          range = bst_db_meter_get_scale (dbmeter, 1);
-          bst_db_scale_hook_up_param (range, rvolume);
-          g_signal_connect_object (range, "button-press-event", G_CALLBACK (grab_focus_and_false), rspinner, G_CONNECT_SWAPPED);
+          bst_db_scale_hook_up_param (range, volume_db);
+          g_signal_connect_object (range, "button-press-event", G_CALLBACK (grab_focus_and_false), vspinner, G_CONNECT_SWAPPED);
           self->lbeam = bst_db_meter_get_beam (dbmeter, 0);
           if (self->lbeam)
             bst_db_beam_set_value (self->lbeam, -G_MAXDOUBLE);
@@ -177,15 +176,15 @@ bst_bus_editor_set_bus (BstBusEditor *self,
           if (self->rbeam)
             bst_db_beam_set_value (self->rbeam, -G_MAXDOUBLE);
         }
-      gxk_radget_add (self, "spinner-box", lspinner);
-      gxk_radget_add (self, "spinner-box", rspinner);
-      self->params = sfi_ring_prepend (self->params, lvolume);
-      self->params = sfi_ring_prepend (self->params, rvolume);
+      gxk_radget_add (self, "pan-box", panscale);
+      gxk_radget_add (self, "spinner-box", vspinner);
+      gxk_radget_add (self, "spinner-box", pspinner);
+      self->params = sfi_ring_prepend (self->params, volume_db);
+      self->params = sfi_ring_prepend (self->params, pan);
       /* create remaining params */
       bus_build_param (self, "uname", "name-box", NULL, NULL);
       bus_build_param (self, "inputs", "inputs-box", NULL, NULL);
       bus_build_param (self, "mute", "toggle-box", "toggle+label", "M");
-      bus_build_param (self, "sync", "toggle-box", "toggle+label", "Y");
       bus_build_param (self, "solo", "toggle-box", "toggle+label", "S");
       bus_build_param (self, "outputs", "outputs-box", NULL, NULL);
       /* update params */

--- a/beast-gtk/bstbuseditor.cc
+++ b/beast-gtk/bstbuseditor.cc
@@ -90,10 +90,7 @@ get_property_param (BstBusEditor *self,
   Bse::BusH bus = Bse::BusH::down_cast (bse_server.from_proxy (self->item));
   for (auto cxxpspec : Bse::introspection_fields_to_param_list (bus.__aida_aux_data__()))
     {
-      std::string pname = cxxpspec->name;
-      for (auto& c : pname)
-        if (c == '-')
-          c = '_';
+      std::string pname = Bst::name_to_identifier (cxxpspec->name);
 
       if (property == pname)
         return bst_param_new_property (cxxpspec, bus);

--- a/beast-gtk/bstbuseditor.cc
+++ b/beast-gtk/bstbuseditor.cc
@@ -155,7 +155,6 @@ bst_bus_editor_set_bus (BstBusEditor *self,
   if (self->item)
     {
       self->source = Bse::SourceH::down_cast (bse_server.from_proxy (self->item));
-      GParamSpec *pspec;
       SfiRing *ring;
       bse_proxy_connect (self->item,
                          "signal::release", bus_editor_release_item, self,
@@ -163,8 +162,7 @@ bst_bus_editor_set_bus (BstBusEditor *self,
       /* create and hook up volume params & scopes */
       GxkParam *lvolume = get_property_param (self, "left_volume");
       GtkWidget *lspinner = gxk_param_create_editor (lvolume, "spinner");
-      pspec = bse_proxy_get_pspec (self->item, "right-volume");
-      GxkParam *rvolume = bst_param_new_proxy (pspec, self->item);
+      GxkParam *rvolume = get_property_param (self, "right_volume");
       GtkWidget *rspinner = gxk_param_create_editor (rvolume, "spinner");
       BstDBMeter *dbmeter = (BstDBMeter*) gxk_radget_find (self, "db-meter");
       if (dbmeter)

--- a/beast-gtk/bstdbmeter.cc
+++ b/beast-gtk/bstdbmeter.cc
@@ -1511,18 +1511,16 @@ db_meter_build_channels (BstDBMeter *self,
     }
   else if (n_channels == 2)
     {
-      /* scale + dash + beam */
-      bst_db_meter_create_scale (self, padding);
-      bst_db_meter_create_dashes (self, GTK_JUSTIFY_FILL, padding);
-      bst_db_meter_create_beam (self, padding);
-      /* dash + number + dash */
-      bst_db_meter_create_dashes (self, GTK_JUSTIFY_LEFT, padding);
+      /* number + dash + scale */
       bst_db_meter_create_numbers (self, MAX (padding - 1, 0));
       bst_db_meter_create_dashes (self, GTK_JUSTIFY_RIGHT, padding);
-      /* beam + dash + scale */
+      bst_db_meter_create_scale (self, padding);
+
+      /* dash + beam + beam + dash */
+      bst_db_meter_create_dashes (self, GTK_JUSTIFY_FILL, padding);
+      bst_db_meter_create_beam (self, padding);
       bst_db_meter_create_beam (self, padding);
       bst_db_meter_create_dashes (self, GTK_JUSTIFY_FILL, padding);
-      bst_db_meter_create_scale (self, padding);
     }
 }
 

--- a/beast-gtk/bstparam.cc
+++ b/beast-gtk/bstparam.cc
@@ -426,20 +426,6 @@ bst_param_new_rec (GParamSpec *pspec,
 // == Aida::Parameter binding ==
 static Bse::ObjectS* aida_property_binding_object (GxkParam *param);
 
-static std::string
-name_to_identifier (const std::string &name)
-{
-  if (strchr (name.c_str(), '-'))
-    {
-      std::string identifier (name);
-      for (size_t i = 0; i < identifier.size(); i++)
-        if (identifier[i] == '-')
-          identifier[i] = '_';
-      return identifier;
-    }
-  return name;
-}
-
 static void
 aida_property_binding_set_value (GxkParam *param, const GValue *value)
 {
@@ -472,8 +458,8 @@ aida_property_binding_set_value (GxkParam *param, const GValue *value)
       Bse::warning ("%s: unsupported type: %s", __func__, g_type_name (G_PARAM_SPEC_VALUE_TYPE (param->pspec)));
       return;
     }
-  if (!objectp->__aida_set__ (name_to_identifier (pspec->name), any))
-    Bse::warning ("%s: __aida_set__: unknown value name: %s", __func__, name_to_identifier (pspec->name));
+  if (!objectp->__aida_set__ (Bst::name_to_identifier (pspec->name), any))
+    Bse::warning ("%s: __aida_set__: unknown value name: %s", __func__, Bst::name_to_identifier (pspec->name));
 }
 
 static void
@@ -481,9 +467,9 @@ aida_property_binding_get_value (GxkParam *param, GValue *param_value)
 {
   Bse::ObjectS *objectp = aida_property_binding_object (param);
   GParamSpec *pspec = param->pspec;
-  Any any = objectp->__aida_get__ (name_to_identifier (pspec->name));
+  Any any = objectp->__aida_get__ (Bst::name_to_identifier (pspec->name));
   if (any.empty())
-    Bse::warning ("%s: __aida_get__: unknown value name: %s (empty return value)", __func__, name_to_identifier (pspec->name));
+    Bse::warning ("%s: __aida_get__: unknown value name: %s (empty return value)", __func__, Bst::name_to_identifier (pspec->name));
   GValue value = { 0, };
   switch (G_TYPE_FUNDAMENTAL (G_PARAM_SPEC_VALUE_TYPE (param->pspec)))
     {
@@ -568,7 +554,7 @@ bst_param_new_property (GParamSpec *pspec, const Bse::ObjectH handle)
   auto notify = [param] (const Aida::Event &event) {
     gxk_param_update (param);
   };
-  objectp->on (String ("notify:") + name_to_identifier (param->pspec->name), notify);
+  objectp->on (String ("notify:") + Bst::name_to_identifier (param->pspec->name), notify);
   gxk_param_set_size_group (param, param_size_group);
   return param;
 }

--- a/beast-gtk/bstutils.cc
+++ b/beast-gtk/bstutils.cc
@@ -159,6 +159,21 @@ monitor_fields_from_shm (int64 shm_id, uint32 shm_offset)
   return MonitorFieldU { (char*) (shm_start + shm_offset) };
 }
 
+// param spec helper: name -> identifier
+std::string
+name_to_identifier (const std::string &name)
+{
+  if (strchr (name.c_str(), '-'))
+    {
+      std::string identifier (name);
+      for (size_t i = 0; i < identifier.size(); i++)
+        if (identifier[i] == '-')
+          identifier[i] = '_';
+      return identifier;
+    }
+  return name;
+}
+
 } // Bst
 
 /* --- variables --- */
@@ -424,6 +439,7 @@ bst_background_handler2_add (gboolean       (*handler) (gpointer data),
 {
   bst_background_handler_add (handler, data, free_func, 2);
 }
+
 
 /* --- packing utilities --- */
 #define SPACING 3

--- a/beast-gtk/bstutils.hh
+++ b/beast-gtk/bstutils.hh
@@ -39,6 +39,8 @@ public:
 
 MonitorFieldU monitor_fields_from_shm (int64 shm_id, uint32 shm_offset);
 
+std::string name_to_identifier (const std::string &name);
+
 } // Bst
 
 // == Bse Server (BSE remote origin) ==

--- a/bse/bseapi.idl
+++ b/bse/bseapi.idl
@@ -992,15 +992,15 @@ interface Bus : SubSynth {
   // ItemSeq   inputs        = Object ("Input Signals", "Synthesis signals (from tracks and busses) used as bus input", GUI ":item-sequence");
   // ItemSeq   outputs       = Object ("Output Signals", "Mixer busses used as output for synthesis signals", GUI ":item-sequence");
   // CSynth    snet          = Object ("SNet", "Synthesis network used internally to implement effect stack", READWRITE ":skip-undo");
-  // float64   left_volume   = Num    ("Left Volume",  "Volume adjustment in decibel of left bus channel",  STANDARD ":scale:db-volume");
-  // float64   right_volume  = Num    ("Right Volume", "Volume adjustment in decibel of right bus channel", STANDARD ":scale:db-volume");
   // bool      master_output = Bool   ("Master Output", "", STORAGE ":skip-default", FALSE);
   group _("Adjustments") {
-    bool mute = Bool (_("Mute"), _("Mute: turn off the bus volume"), STANDARD SKIP_DEFAULT, false);
-    bool solo = Bool (_("Solo"), _("Solo: mute all other busses"), STANDARD SKIP_DEFAULT, false);
-    bool sync = Bool (_("Sync"), _("Synchronize left and right volume"), STANDARD SKIP_DEFAULT, true);
-    float64 left_volume = Range (_("Left Volume"), _("Volume adjustment in decibel of left bus channel"), STANDARD ":scale:db-volume",
-                                 BUS_VOLUME_MIN, BUS_VOLUME_MAX, BUS_VOLUME_STEP, BUS_VOLUME_DEF);
+    bool    mute         = Bool  (_("Mute"), _("Mute: turn off the bus volume"), STANDARD SKIP_DEFAULT, false);
+    bool    solo         = Bool  (_("Solo"), _("Solo: mute all other busses"), STANDARD SKIP_DEFAULT, false);
+    bool    sync         = Bool  (_("Sync"), _("Synchronize left and right volume"), STANDARD SKIP_DEFAULT, true);
+    float64 left_volume  = Range (_("Left Volume"), _("Volume adjustment in decibel of left bus channel"), STANDARD ":scale:db-volume",
+                                  BUS_VOLUME_MIN, BUS_VOLUME_MAX, BUS_VOLUME_STEP, BUS_VOLUME_DEF);
+    float64 right_volume = Range (_("Right Volume"), _("Volume adjustment in decibel of right bus channel"), STANDARD ":scale:db-volume",
+                                  BUS_VOLUME_MIN, BUS_VOLUME_MAX, BUS_VOLUME_STEP, BUS_VOLUME_DEF);
   };
 };
 

--- a/bse/bseapi.idl
+++ b/bse/bseapi.idl
@@ -992,7 +992,6 @@ interface Bus : SubSynth {
   // ItemSeq   inputs        = Object ("Input Signals", "Synthesis signals (from tracks and busses) used as bus input", GUI ":item-sequence");
   // ItemSeq   outputs       = Object ("Output Signals", "Mixer busses used as output for synthesis signals", GUI ":item-sequence");
   // CSynth    snet          = Object ("SNet", "Synthesis network used internally to implement effect stack", READWRITE ":skip-undo");
-  // bool      master_output = Bool   ("Master Output", "", STORAGE ":skip-default", FALSE);
   group _("Adjustments") {
     bool    mute         = Bool  (_("Mute"), _("Mute: turn off the bus volume"), STANDARD SKIP_DEFAULT, false);
     bool    solo         = Bool  (_("Solo"), _("Solo: mute all other busses"), STANDARD SKIP_DEFAULT, false);
@@ -1001,6 +1000,9 @@ interface Bus : SubSynth {
                                   BUS_VOLUME_MIN, BUS_VOLUME_MAX, BUS_VOLUME_STEP, BUS_VOLUME_DEF);
     float64 right_volume = Range (_("Right Volume"), _("Volume adjustment in decibel of right bus channel"), STANDARD ":scale:db-volume",
                                   BUS_VOLUME_MIN, BUS_VOLUME_MAX, BUS_VOLUME_STEP, BUS_VOLUME_DEF);
+  };
+  group _("Internals") {
+    bool master_output = Bool (_("Master Output"), "", STORAGE SKIP_DEFAULT, false);
   };
 };
 

--- a/bse/bseapi.idl
+++ b/bse/bseapi.idl
@@ -987,13 +987,13 @@ interface Bus : SubSynth {
   // ItemSeq   inputs        = Object ("Input Signals", "Synthesis signals (from tracks and busses) used as bus input", GUI ":item-sequence");
   // ItemSeq   outputs       = Object ("Output Signals", "Mixer busses used as output for synthesis signals", GUI ":item-sequence");
   // CSynth    snet          = Object ("SNet", "Synthesis network used internally to implement effect stack", READWRITE ":skip-undo");
-  // bool      sync          = Bool   ("Sync", "Synchronize left and right volume", STANDARD ":skip-default", TRUE);
   // float64   left_volume   = Num    ("Left Volume",  "Volume adjustment in decibel of left bus channel",  STANDARD ":scale:db-volume");
   // float64   right_volume  = Num    ("Right Volume", "Volume adjustment in decibel of right bus channel", STANDARD ":scale:db-volume");
   // bool      master_output = Bool   ("Master Output", "", STORAGE ":skip-default", FALSE);
   group _("Adjustments") {
     bool mute = Bool (_("Mute"), _("Mute: turn off the bus volume"), STANDARD SKIP_DEFAULT, false);
     bool solo = Bool (_("Solo"), _("Solo: mute all other busses"), STANDARD SKIP_DEFAULT, false);
+    bool sync = Bool (_("Sync"), _("Synchronize left and right volume"), STANDARD SKIP_DEFAULT, true);
   };
 };
 

--- a/bse/bseapi.idl
+++ b/bse/bseapi.idl
@@ -987,13 +987,13 @@ interface Bus : SubSynth {
   // ItemSeq   inputs        = Object ("Input Signals", "Synthesis signals (from tracks and busses) used as bus input", GUI ":item-sequence");
   // ItemSeq   outputs       = Object ("Output Signals", "Mixer busses used as output for synthesis signals", GUI ":item-sequence");
   // CSynth    snet          = Object ("SNet", "Synthesis network used internally to implement effect stack", READWRITE ":skip-undo");
-  // bool      solo          = Bool   ("Solo", "Solo: mute all other busses",      STANDARD ":skip-default", FALSE);
   // bool      sync          = Bool   ("Sync", "Synchronize left and right volume", STANDARD ":skip-default", TRUE);
   // float64   left_volume   = Num    ("Left Volume",  "Volume adjustment in decibel of left bus channel",  STANDARD ":scale:db-volume");
   // float64   right_volume  = Num    ("Right Volume", "Volume adjustment in decibel of right bus channel", STANDARD ":scale:db-volume");
   // bool      master_output = Bool   ("Master Output", "", STORAGE ":skip-default", FALSE);
   group _("Adjustments") {
     bool mute = Bool (_("Mute"), _("Mute: turn off the bus volume"), STANDARD SKIP_DEFAULT, false);
+    bool solo = Bool (_("Solo"), _("Solo: mute all other busses"), STANDARD SKIP_DEFAULT, false);
   };
 };
 

--- a/bse/bseapi.idl
+++ b/bse/bseapi.idl
@@ -977,6 +977,11 @@ sequence TrackPartSeq {
   TrackPart parts;
 };
 
+Const BUS_VOLUME_MIN = 1.58489319246111e-05; /* -96dB */
+Const BUS_VOLUME_MAX = 15.8489319246111;     /* +24dB */
+Const BUS_VOLUME_DEF = 1;
+Const BUS_VOLUME_STEP = 0.1;
+
 /// Interface for effect stacks and per-track audio signal routing to the master output.
 interface Bus : SubSynth {
   Error ensure_output    ();            ///< Ensure that a bus has an output connection.
@@ -994,6 +999,8 @@ interface Bus : SubSynth {
     bool mute = Bool (_("Mute"), _("Mute: turn off the bus volume"), STANDARD SKIP_DEFAULT, false);
     bool solo = Bool (_("Solo"), _("Solo: mute all other busses"), STANDARD SKIP_DEFAULT, false);
     bool sync = Bool (_("Sync"), _("Synchronize left and right volume"), STANDARD SKIP_DEFAULT, true);
+    float64 left_volume = Range (_("Left Volume"), _("Volume adjustment in decibel of left bus channel"), STANDARD ":scale:db-volume",
+                                 BUS_VOLUME_MIN, BUS_VOLUME_MAX, BUS_VOLUME_STEP, BUS_VOLUME_DEF);
   };
 };
 

--- a/bse/bseapi.idl
+++ b/bse/bseapi.idl
@@ -977,11 +977,6 @@ sequence TrackPartSeq {
   TrackPart parts;
 };
 
-Const BUS_VOLUME_MIN = 1.58489319246111e-05; /* -96dB */
-Const BUS_VOLUME_MAX = 15.8489319246111;     /* +24dB */
-Const BUS_VOLUME_DEF = 1;
-Const BUS_VOLUME_STEP = 0.1;
-
 /// Interface for effect stacks and per-track audio signal routing to the master output.
 interface Bus : SubSynth {
   Error ensure_output    ();            ///< Ensure that a bus has an output connection.
@@ -996,10 +991,10 @@ interface Bus : SubSynth {
     bool    mute         = Bool  (_("Mute"), _("Mute: turn off the bus volume"), STANDARD SKIP_DEFAULT, false);
     bool    solo         = Bool  (_("Solo"), _("Solo: mute all other busses"), STANDARD SKIP_DEFAULT, false);
     bool    sync         = Bool  (_("Sync"), _("Synchronize left and right volume"), STANDARD SKIP_DEFAULT, true);
-    float64 left_volume  = Range (_("Left Volume"), _("Volume adjustment in decibel of left bus channel"), STANDARD ":scale:db-volume",
-                                  BUS_VOLUME_MIN, BUS_VOLUME_MAX, BUS_VOLUME_STEP, BUS_VOLUME_DEF);
-    float64 right_volume = Range (_("Right Volume"), _("Volume adjustment in decibel of right bus channel"), STANDARD ":scale:db-volume",
-                                  BUS_VOLUME_MIN, BUS_VOLUME_MAX, BUS_VOLUME_STEP, BUS_VOLUME_DEF);
+    float64 left_volume  = Range (_("Left Volume"), _("Volume factor of the left bus channel"), STANDARD ":scale:db-volume", 0, 1000, 0.1, 1);
+    float64 right_volume = Range (_("Right Volume"), _("Volume factor of the right bus channel"), STANDARD ":scale:db-volume", 0, 1000, 0.1, 1);
+    float64 volume_db    = Range (_("Volume"), _("Total volume of both channels in decibel"), GUI ":scale:db-value", -96, 12, 5, 0);
+    float64 pan          = Range (_("Pan [%]"), _("Pan position for stereo output"), GUI ":scale", -100, 100, 5, 0);
   };
   group _("Internals") {
     bool master_output = Bool (_("Master Output"), "", STORAGE SKIP_DEFAULT, false);

--- a/bse/bseapi.idl
+++ b/bse/bseapi.idl
@@ -987,12 +987,14 @@ interface Bus : SubSynth {
   // ItemSeq   inputs        = Object ("Input Signals", "Synthesis signals (from tracks and busses) used as bus input", GUI ":item-sequence");
   // ItemSeq   outputs       = Object ("Output Signals", "Mixer busses used as output for synthesis signals", GUI ":item-sequence");
   // CSynth    snet          = Object ("SNet", "Synthesis network used internally to implement effect stack", READWRITE ":skip-undo");
-  // bool      mute          = Bool   ("Mute", "Mute: turn off the bus volume",    STANDARD ":skip-default", FALSE);
   // bool      solo          = Bool   ("Solo", "Solo: mute all other busses",      STANDARD ":skip-default", FALSE);
   // bool      sync          = Bool   ("Sync", "Synchronize left and right volume", STANDARD ":skip-default", TRUE);
   // float64   left_volume   = Num    ("Left Volume",  "Volume adjustment in decibel of left bus channel",  STANDARD ":scale:db-volume");
   // float64   right_volume  = Num    ("Right Volume", "Volume adjustment in decibel of right bus channel", STANDARD ":scale:db-volume");
   // bool      master_output = Bool   ("Master Output", "", STORAGE ":skip-default", FALSE);
+  group _("Adjustments") {
+    bool mute = Bool (_("Mute"), _("Mute: turn off the bus volume"), STANDARD SKIP_DEFAULT, false);
+  };
 };
 
 /// Interface for Track and Part objects, as well as meta data for sequencing.

--- a/bse/bsebus.cc
+++ b/bse/bsebus.cc
@@ -1045,13 +1045,13 @@ BusImpl::right_volume (double val)
 bool
 BusImpl::master_output() const
 {
-  BseBus *self = const_cast<BusImpl*> (this)->as<BseBus*>();
-  auto parent = BSE_ITEM (self)->parent;
+  BseBus  *self = const_cast<BusImpl*> (this)->as<BseBus*>();
+  BseItem *parent = BSE_ITEM (self)->parent;
   if (BSE_IS_SONG (parent))
     {
       BseSong *song = BSE_SONG (parent);
       BseBus *master = bse_song_find_master (song);
-      return (self == master);
+      return self == master;
     }
   return false;
 }
@@ -1066,7 +1066,7 @@ BusImpl::master_output (bool val)
       auto prop = "master_output";
       push_property_undo (prop);
 
-      auto parent = BSE_ITEM (self)->parent;
+      BseItem *parent = BSE_ITEM (self)->parent;
       if (BSE_IS_SONG (parent))
         {
           BseSong *song = BSE_SONG (parent);

--- a/bse/bsebus.cc
+++ b/bse/bsebus.cc
@@ -959,7 +959,10 @@ BusImpl::sync (bool val)
 
       self->synced = val;
       if (self->synced)
-        self->right_volume = self->left_volume = center_volume (self->right_volume, self->left_volume);
+        {
+          self->left_volume = center_volume (self->right_volume, self->left_volume);
+          self->right_volume = self->left_volume;
+        }
       bus_volume_changed (self);
 
       notify ("left_volume");

--- a/bse/bsebus.cc
+++ b/bse/bsebus.cc
@@ -1073,14 +1073,15 @@ BusImpl::master_output() const
 }
 
 void
-BusImpl::master_output (bool val)
+BusImpl::set_master_output (bool val, bool undo)
 {
   BseBus *self = as<BseBus*>();
 
   if (val != master_output())
     {
       auto prop = "master_output";
-      push_property_undo (prop);
+      if (undo)
+        push_property_undo (prop);
 
       BseItem *parent = BSE_ITEM (self)->parent;
       if (BSE_IS_SONG (parent))
@@ -1105,6 +1106,18 @@ BusImpl::master_output (bool val)
         }
       notify (prop);
     }
+}
+
+void
+BusImpl::master_output (bool val)
+{
+  return set_master_output (val, true);
+}
+
+void
+BusImpl::master_output_no_undo (bool val)
+{
+  return set_master_output (val, false);
 }
 
 Error

--- a/bse/bsebus.cc
+++ b/bse/bsebus.cc
@@ -23,7 +23,6 @@ enum
   PROP_INPUTS,
   PROP_OUTPUTS,
   PROP_SNET,
-  PROP_MASTER_OUTPUT,
 };
 
 
@@ -178,8 +177,9 @@ bus_disconnect_outputs (BseBus *self)
         Bse::warning ("%s:%d: unexpected error: %s", __FILE__, __LINE__, bse_error_blurb (error));
     }
   bse_source_clear_ochannels (BSE_SOURCE (self));       /* also disconnects master */
-  g_object_notify (G_OBJECT (self), "master-output");   /* master may have changed */
-  self->as<Bse::BusImpl*>()->notify ("solo");           /* master may have changed */
+  auto impl = self->as<Bse::BusImpl*>();
+  impl->notify ("master_output");  /* master may have changed */
+  impl->notify ("solo");           /* master may have changed */
 }
 
 static void
@@ -192,8 +192,9 @@ song_connect_master (BseSong        *song,
       BseSource *osource = BSE_SOURCE (bus);
       bse_source_must_set_input (song->postprocess, 0, osource, 0);
       bse_source_must_set_input (song->postprocess, 1, osource, 1);
-      g_object_notify (G_OBJECT (bus), "master-output");
-      bus->as<Bse::BusImpl*>()->notify ("solo");
+      auto impl = bus->as<Bse::BusImpl*>();
+      impl->notify ("master_output");
+      impl->notify ("solo");
     }
 }
 
@@ -367,7 +368,6 @@ bse_bus_set_property (GObject      *object,
   BseBus *self = BSE_BUS (object);
   switch (param_id)
     {
-      BseItem *parent;
     case PROP_INPUTS:
       {
         BseIt3mSeq *i3s = (BseIt3mSeq*) g_value_get_boxed (value);
@@ -385,29 +385,6 @@ bse_bus_set_property (GObject      *object,
     case PROP_SNET:
       g_object_set_property (G_OBJECT (self), "BseSubSynth::snet", value);
       break;
-    case PROP_MASTER_OUTPUT:
-      parent = BSE_ITEM (self)->parent;
-      if (BSE_IS_SONG (parent))
-        {
-          BseSong *song = BSE_SONG (parent);
-          BseBus *master = bse_song_find_master (song);
-          if (sfi_value_get_bool (value))
-            {
-              if (master != self)
-                {
-                  if (master)
-                    bus_disconnect_outputs (master);
-                  bus_disconnect_outputs (self);
-                  song_connect_master (song, self);
-                }
-            }
-          else
-            {
-              if (master == self)
-                bus_disconnect_outputs (self);
-            }
-        }
-      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, param_id, pspec);
       break;
@@ -423,7 +400,6 @@ bse_bus_get_property (GObject    *object,
   BseBus *self = BSE_BUS (object);
   switch (param_id)
     {
-      BseItem *parent;
       BseIt3mSeq *iseq;
       SfiRing *ring;
     case PROP_INPUTS:
@@ -444,17 +420,6 @@ bse_bus_get_property (GObject    *object,
       break;
     case PROP_SNET:
       g_object_get_property (G_OBJECT (self), "BseSubSynth::snet", value);
-      break;
-    case PROP_MASTER_OUTPUT:
-      parent = BSE_ITEM (self)->parent;
-      if (BSE_IS_SONG (parent))
-        {
-          BseSong *song = BSE_SONG (parent);
-          BseBus *master = bse_song_find_master (song);
-          sfi_value_set_bool (value, self == master);
-        }
-      else
-        sfi_value_set_bool (value, FALSE);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, param_id, pspec);
@@ -869,10 +834,6 @@ bse_bus_class_init (BseBusClass *klass)
                                                     _("Mixer busses used as output for synthesis signals"),
                                                     BSE_TYPE_IT3M_SEQ, SFI_PARAM_GUI ":item-sequence"));
   bse_object_class_add_param (object_class, NULL, PROP_SNET, bse_param_spec_object ("snet", NULL, NULL, BSE_TYPE_CSYNTH, SFI_PARAM_READWRITE ":skip-undo"));
-  bse_object_class_add_param (object_class, _("Internals"),
-			      PROP_MASTER_OUTPUT,
-			      sfi_pspec_bool ("master-output", _("Master Output"), NULL,
-                                              FALSE, SFI_PARAM_STORAGE ":skip-default"));
 
   channel_id = bse_source_class_add_ichannel (source_class, "left-audio-in", _("Left Audio In"), _("Left channel input"));
   assert_return (channel_id == BSE_BUS_ICHANNEL_LEFT);
@@ -1074,6 +1035,55 @@ BusImpl::right_volume (double val)
         }
       bus_volume_changed (self);
 
+      notify (prop);
+    }
+}
+
+bool
+BusImpl::master_output() const
+{
+  BseBus *self = const_cast<BusImpl*> (this)->as<BseBus*>();
+  auto parent = BSE_ITEM (self)->parent;
+  if (BSE_IS_SONG (parent))
+    {
+      BseSong *song = BSE_SONG (parent);
+      BseBus *master = bse_song_find_master (song);
+      return (self == master);
+    }
+  return false;
+}
+
+void
+BusImpl::master_output (bool val)
+{
+  BseBus *self = as<BseBus*>();
+
+  if (val != master_output())
+    {
+      auto prop = "master_output";
+      push_property_undo (prop);
+
+      auto parent = BSE_ITEM (self)->parent;
+      if (BSE_IS_SONG (parent))
+        {
+          BseSong *song = BSE_SONG (parent);
+          BseBus *master = bse_song_find_master (song);
+          if (val)
+            {
+              if (master != self)
+                {
+                  if (master)
+                    bus_disconnect_outputs (master);
+                  bus_disconnect_outputs (self);
+                  song_connect_master (song, self);
+                }
+            }
+          else
+            {
+              if (master == self)
+                bus_disconnect_outputs (self);
+            }
+        }
       notify (prop);
     }
 }

--- a/bse/bsebus.cc
+++ b/bse/bsebus.cc
@@ -23,7 +23,6 @@ enum
   PROP_INPUTS,
   PROP_OUTPUTS,
   PROP_SNET,
-  PROP_RIGHT_VOLUME,
   PROP_MASTER_OUTPUT,
 };
 
@@ -386,15 +385,6 @@ bse_bus_set_property (GObject      *object,
     case PROP_SNET:
       g_object_set_property (G_OBJECT (self), "BseSubSynth::snet", value);
       break;
-    case PROP_RIGHT_VOLUME:
-      self->right_volume = sfi_value_get_real (value);
-      if (self->synced)
-        {
-          self->left_volume = self->right_volume;
-          self->as<Bse::BusImpl*>()->notify ("left_volume");
-        }
-      bus_volume_changed (self);
-      break;
     case PROP_MASTER_OUTPUT:
       parent = BSE_ITEM (self)->parent;
       if (BSE_IS_SONG (parent))
@@ -454,9 +444,6 @@ bse_bus_get_property (GObject    *object,
       break;
     case PROP_SNET:
       g_object_get_property (G_OBJECT (self), "BseSubSynth::snet", value);
-      break;
-    case PROP_RIGHT_VOLUME:
-      sfi_value_set_real (value, self->synced ? center_volume (self->left_volume, self->right_volume) : self->right_volume);
       break;
     case PROP_MASTER_OUTPUT:
       parent = BSE_ITEM (self)->parent;
@@ -867,10 +854,6 @@ bse_bus_class_init (BseBusClass *klass)
   source_class->context_connect = bse_bus_context_connect;
   source_class->reset = bse_bus_reset;
 
-  bse_object_class_add_param (object_class, _("Adjustments"), PROP_RIGHT_VOLUME,
-			      sfi_pspec_real ("right-volume", _("Right Volume"), _("Volume adjustment in decibel of right bus channel"),
-                                              bse_db_to_factor (0), bse_db_to_factor (BSE_MINDB), bse_db_to_factor (+24),
-                                              bse_db_to_factor (0.1), SFI_PARAM_STANDARD ":scale:db-volume"));
   bse_object_class_add_param (object_class, _("Signal Inputs"),
                               PROP_INPUTS,
                               /* SYNC: type partitions determine the order of displayed objects */
@@ -1019,7 +1002,7 @@ BusImpl::sync (bool val)
       bus_volume_changed (self);
 
       notify ("left_volume");
-      g_object_notify (G_OBJECT (self), "right-volume");
+      notify ("right_volume");
       notify (prop);
     }
   self->saved_sync = self->synced;
@@ -1057,7 +1040,37 @@ BusImpl::left_volume (double val)
       if (self->synced)
         {
           self->right_volume = self->left_volume;
-          g_object_notify (G_OBJECT (self), "right-volume");
+          notify ("right_volume");
+        }
+      bus_volume_changed (self);
+
+      notify (prop);
+    }
+}
+
+double
+BusImpl::right_volume() const
+{
+  BseBus *self = const_cast<BusImpl*> (this)->as<BseBus*>();
+
+  return self->synced ? center_volume (self->left_volume, self->right_volume) : self->right_volume;
+}
+
+void
+BusImpl::right_volume (double val)
+{
+  BseBus *self = as<BseBus*>();
+
+  if (val != self->right_volume)
+    {
+      auto prop = "right_volume";
+      push_property_undo (prop);
+
+      self->right_volume = volume_clamp (val);
+      if (self->synced)
+        {
+          self->left_volume = self->right_volume;
+          notify ("left_volume");
         }
       bus_volume_changed (self);
 

--- a/bse/bsebus.cc
+++ b/bse/bsebus.cc
@@ -23,7 +23,6 @@ enum
   PROP_INPUTS,
   PROP_OUTPUTS,
   PROP_SNET,
-  PROP_SYNC,
   PROP_LEFT_VOLUME,
   PROP_RIGHT_VOLUME,
   PROP_MASTER_OUTPUT,
@@ -371,7 +370,6 @@ bse_bus_set_property (GObject      *object,
   switch (param_id)
     {
       BseItem *parent;
-      gboolean vbool;
     case PROP_INPUTS:
       {
         BseIt3mSeq *i3s = (BseIt3mSeq*) g_value_get_boxed (value);
@@ -388,19 +386,6 @@ bse_bus_set_property (GObject      *object,
       break;
     case PROP_SNET:
       g_object_set_property (G_OBJECT (self), "BseSubSynth::snet", value);
-      break;
-    case PROP_SYNC:
-      vbool = sfi_value_get_bool (value);
-      if (vbool != self->synced)
-        {
-          self->synced = vbool;
-          if (self->synced)
-            self->right_volume = self->left_volume = center_volume (self->right_volume, self->left_volume);
-          bus_volume_changed (self);
-          g_object_notify (G_OBJECT (self), "left-volume");
-          g_object_notify (G_OBJECT (self), "right-volume");
-        }
-      self->saved_sync = self->synced;
       break;
     case PROP_LEFT_VOLUME:
       self->left_volume = sfi_value_get_real (value);
@@ -479,9 +464,6 @@ bse_bus_get_property (GObject    *object,
       break;
     case PROP_SNET:
       g_object_get_property (G_OBJECT (self), "BseSubSynth::snet", value);
-      break;
-    case PROP_SYNC:
-      g_value_set_boolean (value, self->synced);
       break;
     case PROP_LEFT_VOLUME:
       sfi_value_set_real (value, self->synced ? center_volume (self->left_volume, self->right_volume) : self->left_volume);
@@ -842,9 +824,8 @@ bus_restore_finish (BseObject *object,
 {
   BseBus *self = BSE_BUS (object);
   /* restore real sync setting */
-  g_object_set (self, /* no undo */
-                "sync", self->saved_sync,
-                NULL);
+  auto impl = self->as<Bse::BusImpl*>();
+  impl->sync (self->saved_sync);
   BSE_OBJECT_CLASS (bus_parent_class)->restore_finish (object, vmajor, vminor, vmicro);
 }
 
@@ -899,8 +880,6 @@ bse_bus_class_init (BseBusClass *klass)
   source_class->context_connect = bse_bus_context_connect;
   source_class->reset = bse_bus_reset;
 
-  bse_object_class_add_param (object_class, _("Adjustments"), PROP_SYNC,
-                              sfi_pspec_bool ("sync", _("Sync"), _("Syncronize left and right volume"), TRUE, SFI_PARAM_STANDARD ":skip-default"));
   bse_object_class_add_param (object_class, _("Adjustments"), PROP_LEFT_VOLUME,
 			      sfi_pspec_real ("left-volume", _("Left Volume"), _("Volume adjustment in decibel of left bus channel"),
                                               bse_db_to_factor (0), bse_db_to_factor (BSE_MINDB), bse_db_to_factor (+24),
@@ -1031,6 +1010,36 @@ BusImpl::solo (bool is_solo)
         }
       notify (prop);
     }
+}
+
+bool
+BusImpl::sync() const
+{
+  BseBus *self = const_cast<BusImpl*> (this)->as<BseBus*>();
+
+  return self->synced;
+}
+
+void
+BusImpl::sync (bool val)
+{
+  BseBus *self = as<BseBus*>();
+
+  if (val != self->synced)
+    {
+      auto prop = "sync";
+      push_property_undo (prop);
+
+      self->synced = val;
+      if (self->synced)
+        self->right_volume = self->left_volume = center_volume (self->right_volume, self->left_volume);
+      bus_volume_changed (self);
+
+      g_object_notify (G_OBJECT (self), "left-volume");
+      g_object_notify (G_OBJECT (self), "right-volume");
+      notify (prop);
+    }
+  self->saved_sync = self->synced;
 }
 
 Error

--- a/bse/bsebus.cc
+++ b/bse/bsebus.cc
@@ -23,7 +23,6 @@ enum
   PROP_INPUTS,
   PROP_OUTPUTS,
   PROP_SNET,
-  PROP_SOLO,
   PROP_SYNC,
   PROP_LEFT_VOLUME,
   PROP_RIGHT_VOLUME,
@@ -183,7 +182,7 @@ bus_disconnect_outputs (BseBus *self)
     }
   bse_source_clear_ochannels (BSE_SOURCE (self));       /* also disconnects master */
   g_object_notify (G_OBJECT (self), "master-output");   /* master may have changed */
-  g_object_notify (G_OBJECT (self), "solo");            /* master may have changed */
+  self->as<Bse::BusImpl*>()->notify ("solo");           /* master may have changed */
 }
 
 static void
@@ -197,7 +196,7 @@ song_connect_master (BseSong        *song,
       bse_source_must_set_input (song->postprocess, 0, osource, 0);
       bse_source_must_set_input (song->postprocess, 1, osource, 1);
       g_object_notify (G_OBJECT (bus), "master-output");
-      g_object_notify (G_OBJECT (bus), "solo");
+      bus->as<Bse::BusImpl*>()->notify ("solo");
     }
 }
 
@@ -390,18 +389,6 @@ bse_bus_set_property (GObject      *object,
     case PROP_SNET:
       g_object_set_property (G_OBJECT (self), "BseSubSynth::snet", value);
       break;
-    case PROP_SOLO:
-      parent = BSE_ITEM (self)->parent;
-      if (BSE_IS_SONG (parent))
-        {
-          BseSong *song = BSE_SONG (parent);
-          gboolean is_solo = sfi_value_get_bool (value);
-          if (is_solo && song->solo_bus != self)
-            bse_song_set_solo_bus (song, self);
-          else if (!is_solo && song->solo_bus == self)
-            bse_song_set_solo_bus (song, NULL);
-        }
-      break;
     case PROP_SYNC:
       vbool = sfi_value_get_bool (value);
       if (vbool != self->synced)
@@ -493,16 +480,6 @@ bse_bus_get_property (GObject    *object,
     case PROP_SNET:
       g_object_get_property (G_OBJECT (self), "BseSubSynth::snet", value);
       break;
-    case PROP_SOLO:
-      parent = BSE_ITEM (self)->parent;
-      if (BSE_IS_SONG (parent))
-        {
-          BseSong *song = BSE_SONG (parent);
-          g_value_set_boolean (value, song->solo_bus == self);
-        }
-      else
-        g_value_set_boolean (value, FALSE);
-      break;
     case PROP_SYNC:
       g_value_set_boolean (value, self->synced);
       break;
@@ -535,8 +512,10 @@ bse_bus_change_solo (BseBus         *self,
 {
   self->solo_muted = solo_muted;
   bus_volume_changed (self);
-  g_object_notify (G_OBJECT (self), "solo");
-  self->as<Bse::SongImpl*>()->notify ("mute");
+
+  auto impl = self->as<Bse::BusImpl*>();
+  impl->notify ("solo");
+  impl->notify ("mute");
 }
 
 static void
@@ -920,8 +899,6 @@ bse_bus_class_init (BseBusClass *klass)
   source_class->context_connect = bse_bus_context_connect;
   source_class->reset = bse_bus_reset;
 
-  bse_object_class_add_param (object_class, _("Adjustments"), PROP_SOLO,
-                              sfi_pspec_bool ("solo", _("Solo"), _("Solo: mute all other busses"), FALSE, SFI_PARAM_STANDARD ":skip-default"));
   bse_object_class_add_param (object_class, _("Adjustments"), PROP_SYNC,
                               sfi_pspec_bool ("sync", _("Sync"), _("Syncronize left and right volume"), TRUE, SFI_PARAM_STANDARD ":skip-default"));
   bse_object_class_add_param (object_class, _("Adjustments"), PROP_LEFT_VOLUME,
@@ -1004,7 +981,7 @@ BusImpl::mute() const
 void
 BusImpl::mute (bool val)
 {
-  BseBus *self = const_cast<BusImpl*> (this)->as<BseBus*>();
+  BseBus *self = as<BseBus*>();
 
   if (self->muted != val)
     {
@@ -1014,6 +991,44 @@ BusImpl::mute (bool val)
       self->muted = val;
       bus_volume_changed (self);
 
+      notify (prop);
+    }
+}
+
+bool
+BusImpl::solo() const
+{
+  BseBus  *self = const_cast<BusImpl*> (this)->as<BseBus*>();
+  BseItem *parent = BSE_ITEM (self)->parent;
+
+  if (BSE_IS_SONG (parent))
+    {
+      BseSong *song = BSE_SONG (parent);
+      return song->solo_bus == self;
+    }
+  return false;
+}
+
+void
+BusImpl::solo (bool is_solo)
+{
+  BseBus *self = as<BseBus*>();
+
+  if (solo() != is_solo)
+    {
+      auto prop = "solo";
+      push_property_undo (prop);
+
+      BseItem *parent = BSE_ITEM (self)->parent;
+      if (BSE_IS_SONG (parent))
+        {
+          BseSong *song = BSE_SONG (parent);
+
+          if (is_solo && song->solo_bus != self)
+            bse_song_set_solo_bus (song, self);
+          else if (!is_solo && song->solo_bus == self)
+            bse_song_set_solo_bus (song, NULL);
+        }
       notify (prop);
     }
 }

--- a/bse/bsebus.cc
+++ b/bse/bsebus.cc
@@ -23,7 +23,6 @@ enum
   PROP_INPUTS,
   PROP_OUTPUTS,
   PROP_SNET,
-  PROP_MUTE,
   PROP_SOLO,
   PROP_SYNC,
   PROP_LEFT_VOLUME,
@@ -391,10 +390,6 @@ bse_bus_set_property (GObject      *object,
     case PROP_SNET:
       g_object_set_property (G_OBJECT (self), "BseSubSynth::snet", value);
       break;
-    case PROP_MUTE:
-      self->muted = sfi_value_get_bool (value);
-      bus_volume_changed (self);
-      break;
     case PROP_SOLO:
       parent = BSE_ITEM (self)->parent;
       if (BSE_IS_SONG (parent))
@@ -498,9 +493,6 @@ bse_bus_get_property (GObject    *object,
     case PROP_SNET:
       g_object_get_property (G_OBJECT (self), "BseSubSynth::snet", value);
       break;
-    case PROP_MUTE:
-      g_value_set_boolean (value, self->muted);
-      break;
     case PROP_SOLO:
       parent = BSE_ITEM (self)->parent;
       if (BSE_IS_SONG (parent))
@@ -544,7 +536,7 @@ bse_bus_change_solo (BseBus         *self,
   self->solo_muted = solo_muted;
   bus_volume_changed (self);
   g_object_notify (G_OBJECT (self), "solo");
-  g_object_notify (G_OBJECT (self), "mute");
+  self->as<Bse::SongImpl*>()->notify ("mute");
 }
 
 static void
@@ -928,8 +920,6 @@ bse_bus_class_init (BseBusClass *klass)
   source_class->context_connect = bse_bus_context_connect;
   source_class->reset = bse_bus_reset;
 
-  bse_object_class_add_param (object_class, _("Adjustments"), PROP_MUTE,
-                              sfi_pspec_bool ("mute", _("Mute"), _("Mute: turn off the bus volume"), FALSE, SFI_PARAM_STANDARD ":skip-default"));
   bse_object_class_add_param (object_class, _("Adjustments"), PROP_SOLO,
                               sfi_pspec_bool ("solo", _("Solo"), _("Solo: mute all other busses"), FALSE, SFI_PARAM_STANDARD ":skip-default"));
   bse_object_class_add_param (object_class, _("Adjustments"), PROP_SYNC,
@@ -1002,6 +992,31 @@ BusImpl::BusImpl (BseObject *bobj) :
 
 BusImpl::~BusImpl ()
 {}
+
+bool
+BusImpl::mute() const
+{
+  BseBus *self = const_cast<BusImpl*> (this)->as<BseBus*>();
+
+  return self->muted;
+}
+
+void
+BusImpl::mute (bool val)
+{
+  BseBus *self = const_cast<BusImpl*> (this)->as<BseBus*>();
+
+  if (self->muted != val)
+    {
+      auto prop = "mute";
+      push_property_undo (prop);
+
+      self->muted = val;
+      bus_volume_changed (self);
+
+      notify (prop);
+    }
+}
 
 Error
 BusImpl::ensure_output ()

--- a/bse/bsebus.hh
+++ b/bse/bsebus.hh
@@ -79,8 +79,11 @@ protected:
 
   void lr_to_volume_pan (double &volume_out, double &pan_out) const;
   void volume_pan_to_lr (double volume_in, double pan_in);
+  void set_master_output (bool val, bool undo);
 
 public:
+  void master_output_no_undo (bool val);
+
   explicit          BusImpl          (BseObject*);
   virtual bool      mute             () const override;
   virtual void      mute             (bool val) override;

--- a/bse/bsebus.hh
+++ b/bse/bsebus.hh
@@ -86,6 +86,8 @@ public:
   virtual void      solo             (bool val) override;
   virtual bool      sync             () const override;
   virtual void      sync             (bool val) override;
+  virtual double    left_volume      () const override;
+  virtual void      left_volume      (double val) override;
   virtual Error     ensure_output    () override;
   virtual Error     connect_bus      (BusIface &bus) override;
   virtual Error     connect_track    (TrackIface &track) override;

--- a/bse/bsebus.hh
+++ b/bse/bsebus.hh
@@ -88,6 +88,8 @@ public:
   virtual void      sync             (bool val) override;
   virtual double    left_volume      () const override;
   virtual void      left_volume      (double val) override;
+  virtual double    right_volume     () const override;
+  virtual void      right_volume     (double val) override;
   virtual Error     ensure_output    () override;
   virtual Error     connect_bus      (BusIface &bus) override;
   virtual Error     connect_track    (TrackIface &track) override;

--- a/bse/bsebus.hh
+++ b/bse/bsebus.hh
@@ -84,6 +84,8 @@ public:
   virtual void      mute             (bool val) override;
   virtual bool      solo             () const override;
   virtual void      solo             (bool val) override;
+  virtual bool      sync             () const override;
+  virtual void      sync             (bool val) override;
   virtual Error     ensure_output    () override;
   virtual Error     connect_bus      (BusIface &bus) override;
   virtual Error     connect_track    (TrackIface &track) override;

--- a/bse/bsebus.hh
+++ b/bse/bsebus.hh
@@ -78,6 +78,10 @@ namespace Bse {
 class BusImpl : public SubSynthImpl, public virtual BusIface {
 protected:
   virtual          ~BusImpl          ();
+
+  void lr_to_volume_pan (double &volume_out, double &pan_out) const;
+  void volume_pan_to_lr (double volume_in, double pan_in);
+
 public:
   explicit          BusImpl          (BseObject*);
   virtual bool      mute             () const override;
@@ -90,6 +94,10 @@ public:
   virtual void      left_volume      (double val) override;
   virtual double    right_volume     () const override;
   virtual void      right_volume     (double val) override;
+  virtual double    volume_db        () const override;
+  virtual void      volume_db        (double val) override;
+  virtual double    pan              () const override;
+  virtual void      pan              (double val) override;
   virtual bool      master_output    () const override;
   virtual void      master_output    (bool val) override;
   virtual Error     ensure_output    () override;

--- a/bse/bsebus.hh
+++ b/bse/bsebus.hh
@@ -80,11 +80,13 @@ protected:
   virtual          ~BusImpl          ();
 public:
   explicit          BusImpl          (BseObject*);
-  virtual Error ensure_output    () override;
-  virtual Error connect_bus      (BusIface &bus) override;
-  virtual Error connect_track    (TrackIface &track) override;
-  virtual Error disconnect_bus   (BusIface &bus) override;
-  virtual Error disconnect_track (TrackIface &track) override;
+  virtual bool      mute             () const override;
+  virtual void      mute             (bool val) override;
+  virtual Error     ensure_output    () override;
+  virtual Error     connect_bus      (BusIface &bus) override;
+  virtual Error     connect_track    (TrackIface &track) override;
+  virtual Error     disconnect_bus   (BusIface &bus) override;
+  virtual Error     disconnect_track (TrackIface &track) override;
 };
 
 } // Bse

--- a/bse/bsebus.hh
+++ b/bse/bsebus.hh
@@ -90,6 +90,8 @@ public:
   virtual void      left_volume      (double val) override;
   virtual double    right_volume     () const override;
   virtual void      right_volume     (double val) override;
+  virtual bool      master_output    () const override;
+  virtual void      master_output    (bool val) override;
   virtual Error     ensure_output    () override;
   virtual Error     connect_bus      (BusIface &bus) override;
   virtual Error     connect_track    (TrackIface &track) override;

--- a/bse/bsebus.hh
+++ b/bse/bsebus.hh
@@ -82,6 +82,8 @@ public:
   explicit          BusImpl          (BseObject*);
   virtual bool      mute             () const override;
   virtual void      mute             (bool val) override;
+  virtual bool      solo             () const override;
+  virtual void      solo             (bool val) override;
   virtual Error     ensure_output    () override;
   virtual Error     connect_bus      (BusIface &bus) override;
   virtual Error     connect_track    (TrackIface &track) override;

--- a/bse/bsebus.hh
+++ b/bse/bsebus.hh
@@ -19,8 +19,6 @@ struct BseBus : BseSubSynth {
   double        left_volume;
   double        right_volume;
   guint         muted : 1;
-  guint         synced : 1;
-  guint         saved_sync : 1;
   guint         solo_muted : 1;
   BseSource    *summation;
   BseSource    *vin;

--- a/bse/bseitem.cc
+++ b/bse/bseitem.cc
@@ -1038,7 +1038,7 @@ ItemImpl::resolve_undo_descriptor_data (const UndoDescriptorData &udd)
   if (udd.upath == "\002project\003")
     return *project;
   BseItem *bitem = bse_container_resolve_upath (bproject, udd.upath.c_str());
-  if (bitem != NULL)    // undo descriptor for NULL objects is not currently supported
+  if (!bitem)    // undo descriptor for NULL objects is not currently supported
     fatal_error ("item undo path failed to resolve");
   return *bitem->as<ItemImpl*>();
 }

--- a/bse/bsesong.cc
+++ b/bse/bsesong.cc
@@ -497,8 +497,8 @@ bse_song_ensure_master (BseSong *self)
     {
       BseUndoStack *ustack = bse_item_undo_open (self, "Create Master");
       child = (BseSource*) bse_container_new_child_bname (BSE_CONTAINER (self), BSE_TYPE_BUS, master_bus_name(), NULL);
-      g_object_set (child, "master-output", TRUE, NULL); // not-undoable
       Bse::BusImpl *bus = child->as<Bse::BusImpl*>();
+      bus->master_output_no_undo (true); // not undoable
       Bse::ItemImpl::UndoDescriptor<Bse::BusImpl> bus_descriptor = this_->undo_descriptor (*bus);
       auto remove_bus_lambda = [bus_descriptor] (Bse::SongImpl &self, BseUndoStack *ustack) -> Bse::Error {
         Bse::BusImpl &bus = self.undo_resolve (bus_descriptor);
@@ -681,7 +681,7 @@ SongImpl::remove_bus (BusIface &bus_iface)
   BseItem *child = bus.as<BseItem*>();
   BseUndoStack *ustack = bse_item_undo_open (self, __func__);
   // reset ::master-output property undoable
-  bse_item_set (child, "master-output", FALSE, NULL);
+  bus.master_output (false);
   // backup object references to undo stack
   bse_container_uncross_undoable (BSE_CONTAINER (self), child);
   // implement "undo" of bse_container_remove_backedup, i.e. redo

--- a/bse/bsestorage.cc
+++ b/bse/bsestorage.cc
@@ -739,6 +739,16 @@ storage_parse_property_value (BseStorage *self, const std::string &name, Bse::An
 {
   assert_return (BSE_IS_STORAGE (self), G_TOKEN_ERROR);
   GScanner *scanner = bse_storage_get_scanner (self);
+  if (any.kind() == Aida::FLOAT64) /* float format cannot be handled by scanner_parse_paren_rest */
+    {
+      double value;
+      GTokenType expected_token = sfi_scanner_parse_real_num (scanner, &value, nullptr);
+      if (expected_token != G_TOKEN_NONE)
+        return expected_token;
+      any.set (value);
+      parse_or_return (scanner, ')');
+      return G_TOKEN_NONE;
+    }
   std::string rest;
   GTokenType expected_token = scanner_parse_paren_rest (scanner, &rest);
   if (expected_token != G_TOKEN_NONE)

--- a/res/gxk/radgets-beast.xml
+++ b/res/gxk/radgets-beast.xml
@@ -335,6 +335,10 @@
 	  <frame shadow-type="etched-in" expand="1" >
 	    <label label="Volume" />
 	  </frame>
+	  <!-- Pan -->
+	  <frame shadow-type="etched-in" size:window-vgroup="bus-pan-box" >
+	    <label label="Pan" />
+	  </frame>
 	  <!-- VolumeSpinners -->
 	  <arrow arrow-type="down" size:window-vgroup="bus-spinner-box" />
 	  <!-- Outputs -->
@@ -380,6 +384,8 @@
 	  <alignment expand="1">
 	    <db-meter id="db-meter" n-channels="2" />
 	  </alignment>
+	  <!-- Panning -->
+	  <hbox id="pan-box" homogeneous="1" width="1" spacing="3" size:window-vgroup="bus-pan-box"/>
 	  <!-- VolumeSpinners -->
 	  <hbox id="spinner-box" homogeneous="1" width="1" spacing="3" size:window-vgroup="bus-spinner-box" />
 	  <!-- Outputs -->

--- a/sfi/sfiserial.cc
+++ b/sfi/sfiserial.cc
@@ -130,7 +130,7 @@ gstring_check_break (GString  *gstring,
 
 
 /* --- functions --- */
-static GTokenType
+GTokenType
 sfi_scanner_parse_real_num (GScanner *scanner,
 			    SfiReal  *real_p,
 			    SfiNum   *num_p)

--- a/sfi/sfiserial.hh
+++ b/sfi/sfiserial.hh
@@ -19,6 +19,9 @@ void		sfi_value_store_param	        (const GValue	*value,
 						 guint		 indent);
 void            sfi_value_store_stderr          (const GValue   *value);
 
+GTokenType      sfi_scanner_parse_real_num      (GScanner       *scanner,
+                                                 SfiReal        *real_p,
+                                                 SfiNum         *num_p);
 
 /* --- NULL (nil) token handling --- */
 #define  SFI_SERIAL_NULL_TOKEN	"#f"


### PR DESCRIPTION
I managed to port all Bus properties that have a simple type (non-object, non-sequence) to C++. There are two things worth mentioning here.

(1) in bseapi.idl, we have to use non-computed constants, so there is no elegant way of expressing that the maximum is +24dB - however I think we can live with precomputed factors here

for implementing volume_clamp(), it would be nice if we wouldn't have to duplicate the magic numbers. I originally thought the best way to achieve this would be to be able to access the defaults from the parameter, somewhat like
```
left_volume = CLAMP (val, p_left_volume::min(), p_left_volume::max())
```

However, while implementing the code, I've got a new idea: we could simply offer a way to access the bseapi.idl constants, like
``` 
Const BUS_VOLUME_MIN = 1.58489319246111e-05; /* -96dB */
```
should define a C++ constant, also, and this could be used to implement volume_clamp().

(2) I think C++ properties are commonly referred to as "left_volume" (underscore instead of minus) - I however found the introspected paramspecs in the ui code contain minus, so I use a hacky translation for finding the pspec - not sure if that is the right thing to do here.