### PR TITLE
BSE: SF2: use shared engine module instead of global soundfont lock

### DIFF
--- a/bse/bsesoundfontosc.hh
+++ b/bse/bsesoundfontosc.hh
@@ -20,6 +20,12 @@ enum
   BSE_SOUND_FONT_OSC_N_OCHANNELS
 };
 
+enum
+{
+  BSE_SOUND_FONT_OSC_ICHANNEL_DEPEND_IN,
+  BSE_SOUND_FONT_OSC_N_ICHANNELS
+};
+
 struct BseSoundFontOscConfig {
   int			osc_id;
   int			sfont_id;

--- a/bse/bsesoundfontrepo.hh
+++ b/bse/bsesoundfontrepo.hh
@@ -71,6 +71,7 @@ public:
   guint64	              channel_values_tick_stamp;
 
   int		              n_channel_oscs_active;	  /* SoundFontOscs with an active module in the engine thread */
+  BseModule                  *common_module = NULL;
 
 protected:
 


### PR DESCRIPTION
This moves SoundFont processing to a common engine module which is connected to all sound font osc modules. This ensures that the data is ready when the modules are called, and `process_fluid_L` is only called once in the common module. The global soundfont lock problem should be solved by this PR.

Note that the `sound_font_osc_process` function still acquires the lock for a brief amount of time, but no audio generation takes place while the lock is held.