### PR TITLE
EBEAST: Update electron-packager

### DIFF
--- a/ebeast/package.json.in
+++ b/ebeast/package.json.in
@@ -13,7 +13,7 @@
     "node-gyp": "^3.5.0",
     "node-sass": "^4.5.3",
     "electron-devtools-installer": "^2.2.3",
-    "electron-packager": "^8.6.0",
+    "electron-packager": "^12.2.0",
     "browserify": "^14.1.0",
     "vueify": "^9.4.1",
     "babel-core": "^6.8.0",


### PR DESCRIPTION
Simple version bump because electron-packager fails to run on Node 10+
https://github.com/electron-userland/electron-packager/issues/863