### PR TITLE
One fluid synth per track

### DIFF
--- a/bse/bsesoundfont.cc
+++ b/bse/bsesoundfont.cc
@@ -12,8 +12,6 @@
 
 #define parse_or_return         bse_storage_scanner_parse_or_return
 
-using std::string;
-
 enum {
   PARAM_0,
   PARAM_FILE_NAME,
@@ -186,7 +184,7 @@ bse_sound_font_reload (BseSoundFont *sound_font)
   return bse_sound_font_load_blob (sound_font, sound_font_impl->blob, FALSE);
 }
 
-string
+std::string
 bse_sound_font_get_filename (BseSoundFont *sound_font)
 {
   Bse::SoundFontImpl *sound_font_impl = sound_font->as<Bse::SoundFontImpl *>();

--- a/bse/bsesoundfont.cc
+++ b/bse/bsesoundfont.cc
@@ -128,7 +128,6 @@ bse_sound_font_load_blob (BseSoundFont       *self,
   assert_return (sound_font_impl->sfrepo != NULL, Bse::Error::INTERNAL);
   assert_return (sound_font_impl->sfont_id == -1, Bse::Error::INTERNAL);
 
-  std::lock_guard<std::mutex> guard (bse_sound_font_repo_mutex (sound_font_impl->sfrepo));
   fluid_synth_t *fluid_synth = bse_sound_font_repo_fluid_synth (sound_font_impl->sfrepo);
   int sfont_id = fluid_synth_sfload (fluid_synth, use_searchpath (blob->file_name()).c_str(), 0);
   Bse::Error error;
@@ -170,7 +169,6 @@ bse_sound_font_unload (BseSoundFont *sound_font)
 
   if (sound_font_impl->sfont_id != -1)
     {
-      std::lock_guard<std::mutex> guard (bse_sound_font_repo_mutex (sound_font_impl->sfrepo));
       fluid_synth_t *fluid_synth = bse_sound_font_repo_fluid_synth (sound_font_impl->sfrepo);
 
       fluid_synth_sfunload (fluid_synth, sound_font_impl->sfont_id, 1 /* reset presets */);

--- a/bse/bsesoundfont.cc
+++ b/bse/bsesoundfont.cc
@@ -12,6 +12,8 @@
 
 #define parse_or_return         bse_storage_scanner_parse_or_return
 
+using std::string;
+
 enum {
   PARAM_0,
   PARAM_FILE_NAME,
@@ -186,12 +188,12 @@ bse_sound_font_reload (BseSoundFont *sound_font)
   return bse_sound_font_load_blob (sound_font, sound_font_impl->blob, FALSE);
 }
 
-int
-bse_sound_font_get_id (BseSoundFont *sound_font)
+string
+bse_sound_font_get_filename (BseSoundFont *sound_font)
 {
   Bse::SoundFontImpl *sound_font_impl = sound_font->as<Bse::SoundFontImpl *>();
 
-  return sound_font_impl->sfont_id;
+  return use_searchpath (sound_font_impl->blob->file_name());
 }
 
 static void

--- a/bse/bsesoundfont.hh
+++ b/bse/bsesoundfont.hh
@@ -23,7 +23,7 @@ Bse::Error      bse_sound_font_load_blob	(BseSoundFont       *sound_font,
 						 gboolean            init_presets);
 void		bse_sound_font_unload           (BseSoundFont       *sound_font);
 Bse::Error      bse_sound_font_reload           (BseSoundFont       *sound_font);
-int             bse_sound_font_get_id           (BseSoundFont       *sound_font);
+std::string     bse_sound_font_get_filename     (BseSoundFont       *sound_font);
 
 namespace Bse {
 

--- a/bse/bsesoundfontosc.cc
+++ b/bse/bsesoundfontosc.cc
@@ -585,6 +585,10 @@ bse_sound_font_osc_context_create (BseSource *source,
       fluid_settings_setint (fluid_settings, "synth.audio-groups", 1);
       fluid_settings_setint (fluid_settings, "synth.reverb.active", 0);
       fluid_settings_setint (fluid_settings, "synth.chorus.active", 0);
+      /* we ensure that our fluid_synth instance is only used by one thread at a time
+       *  => we can disable automated locks that protect all fluid synth API calls
+       */
+      fluid_settings_setint (fluid_settings, "synth.threadsafe-api", 0);
 
       self->data.cached_filename = self->data.filename;
       self->data.cached_fluid_synth = new_fluid_synth (fluid_settings);

--- a/bse/bsesoundfontosc.cc
+++ b/bse/bsesoundfontosc.cc
@@ -14,70 +14,19 @@
 /*------------------------------------------------------------------------------------------------
  * overview of how soundfont support is implemented
  *------------------------------------------------------------------------------------------------
- * what we want:
+ * What this does:
  *  - use existing soundfonts & fluidsynth replay code
  *  - be able to use soundfont presets (instruments) instead of synthesis instruments on a
  *    per-track basis
- *  - multiple tracks should be able to share the same soundfont (as these are huge)
  *  - use the standard beast mixer with tracks that use soundfonts
  *
  * To be able to use the fluidsynth API, and let fluidsynth render the output,
  * this code will simply relay the events from the midi receiver to the
- * fluidsynth engine using bse_midi_receiver_add_event_handler. The fluidsynth
- * engine itself has no concept of what tracks exist in BEAST. In fact, to be
- * able to share the same soundfont for many tracks, we have to pass all events
- * from all tracks that use the same soundfont to fluidsynth in one step.
+ * fluidsynth engine using bse_midi_receiver_add_event_handler.
  *
- * To be able to still get many mixer tracks, the code below will create
- * multiple fluidsynth channels, each containing the sample data for one beast
- * track. This make post-processing networks and using the beast mixer work.
- * However, we cannot use fluidsynth effects. This is because fluidsynth can
- * only render one effect track containing the accumulated effects of all input
- * events, whereas we want to be able to process every beast track seperately.
- *
- * However this limitation can be workarounded by using beast to render the
- * effects, either in per-beast-track postprocessing networks or using per-song
- * post-processing network.
- *
- * Now that we have a mapping from the midi events to the fluidsynth output
- * tracks, the only thing that needs to be done is getting the sample data into
- * the bse engine. To do that, we create standard engine modules. These do not
- * compute any sample data.  Instead, they just access memory that is shared
- * between all osc modules. The first sound font osc module that is scheduled
- * by the engine calls process_fluid_L, to update the shared memory containing
- * the fluidsynth output. All other sound font osc engine modules that are
- * called after that simply read the samples that was already computed when the
- * first engine module's process function was called.
- *
- * The check:
- *
- *   gint64 now_tick_stamp = Bse::TickStamp::current();
- *   if (sfrepo->channel_values_tick_stamp != now_tick_stamp)
- *        ...
- *
- * ensures this. Here the shared state is managed by the sound font repo, and
- * only updated once for all sound font engine modules. Locking is used to
- * ensure that there are no races,
- *
- *   bse_sound_font_repo_lock_fluid_synth (sfrepo); 
- *
- * ensures that there is always at most one sound font engine module that has access
- * to the shared state, and so the actual fluidsynth code to process the events and
- * update the shared sample data is also executed exactly once.
- *
- * Note that IF the bse engine WOULD use multiple CPUs (it currently doesn't),
- * the locking forces the sound font osc engine modules to wait for the
- * computation of the first module that got the lock. This may be undesirable
- * since it could block the computations on all CPUs, although other engine
- * modules that are unrelated to fluidsynth could be processed. One possibility
- * to solve this problem would be to enhance the engine and allow the sound
- * font osc modules to use some "CPU affinity" setting which lets the engine
- * know that all these modules should be processed on the same CPU.
- *
- * CPU affinity will also enhance performance (with a muli core bse engine)
- * since then the actual fluid synth rendering code will always run on the same
- * CPU (instead of the CPU that the first engine module runs on, which will can
- * change from engine block to engine block).
+ * For each track, there is one fluid_synth_t instance (one BseSoundFontOsc),
+ * which renders the audio for that track without using fluidsynth effects.
+ * Effects can be added using our mixer.
  *------------------------------------------------------------------------------------------------
  */
 

--- a/bse/bsesoundfontosc.hh
+++ b/bse/bsesoundfontosc.hh
@@ -26,13 +26,17 @@ struct BseSoundFontOscConfig {
   int			program;
   uint                  silence_bound;
   BseSoundFontRepo     *sfrepo;
-  const char           *filename;
 
   int                   update_preset;  /* preset changed indicator */
 };
 struct BseSoundFontOsc : BseSource {
   BseSoundFontPreset   *preset;
   BseSoundFontOscConfig	config;
+
+  /* C++ allocated data */
+  struct Data {
+    std::string         filename;
+  } data;
 };
 struct BseSoundFontOscClass : BseSourceClass
 {};

--- a/bse/bsesoundfontosc.hh
+++ b/bse/bsesoundfontosc.hh
@@ -33,9 +33,17 @@ struct BseSoundFontOsc : BseSource {
   BseSoundFontPreset   *preset;
   BseSoundFontOscConfig	config;
 
+
+
   /* C++ allocated data */
   struct Data {
     std::string         filename;
+
+    fluid_synth_t      *cached_fluid_synth = nullptr;
+    fluid_settings_t   *cached_fluid_settings = nullptr;
+    uint                cached_mix_freq = 0;
+    std::string         cached_filename;
+    int                 cached_sfont_id = 0;
   } data;
 };
 struct BseSoundFontOscClass : BseSourceClass

--- a/bse/bsesoundfontosc.hh
+++ b/bse/bsesoundfontosc.hh
@@ -22,11 +22,11 @@ enum
 
 struct BseSoundFontOscConfig {
   int			osc_id;
-  int			sfont_id;
   int			bank;
   int			program;
-  int                   silence_bound;
+  uint                  silence_bound;
   BseSoundFontRepo     *sfrepo;
+  const char           *filename;
 
   int                   update_preset;  /* preset changed indicator */
 };

--- a/bse/bsesoundfontrepo.cc
+++ b/bse/bsesoundfontrepo.cc
@@ -272,13 +272,6 @@ bse_sound_font_repo_list_all_presets (BseSoundFontRepo *sfrepo, Bse::ItemSeq &it
   gather_presets (BSE_ITEM (sfrepo), &items);
 }
 
-std::mutex&
-bse_sound_font_repo_mutex (BseSoundFontRepo *sfrepo)
-{
-  Bse::SoundFontRepoImpl *sfrepo_impl = sfrepo->as<Bse::SoundFontRepoImpl *>();
-  return sfrepo_impl->fluid_synth_mutex;
-}
-
 fluid_synth_t*
 bse_sound_font_repo_fluid_synth (BseSoundFontRepo *sfrepo)
 {

--- a/bse/bsesoundfontrepo.cc
+++ b/bse/bsesoundfontrepo.cc
@@ -145,18 +145,12 @@ bse_sound_font_repo_prepare (BseSource *source)
       sfrepo_impl->n_fluid_channels = channels_required;
       sfrepo_impl->fluid_mix_freq = mix_freq;
 
-      /* midi channels required must be: at least 16, a multiple of 16 */
-      const int midi_channels_required = (channels_required / 16 + 1) * 16;
-
-      /* audio channels required must not be zero */
-      const int audio_channels_required = std::max<int> (1, channels_required);
-
       fluid_settings_setnum (sfrepo_impl->fluid_settings, "synth.sample-rate", mix_freq);
       /* soundfont instruments should be as loud as beast synthesis network instruments */
       fluid_settings_setnum (sfrepo_impl->fluid_settings, "synth.gain", 1.0);
-      fluid_settings_setint (sfrepo_impl->fluid_settings, "synth.midi-channels", midi_channels_required);
-      fluid_settings_setint (sfrepo_impl->fluid_settings, "synth.audio-channels", audio_channels_required);
-      fluid_settings_setint (sfrepo_impl->fluid_settings, "synth.audio-groups", audio_channels_required);
+      fluid_settings_setint (sfrepo_impl->fluid_settings, "synth.midi-channels", 16);
+      fluid_settings_setint (sfrepo_impl->fluid_settings, "synth.audio-channels", 1);
+      fluid_settings_setint (sfrepo_impl->fluid_settings, "synth.audio-groups", 1);
       fluid_settings_setint (sfrepo_impl->fluid_settings, "synth.reverb.active", 0);
       fluid_settings_setint (sfrepo_impl->fluid_settings, "synth.chorus.active", 0);
 

--- a/bse/bsesoundfontrepo.hh
+++ b/bse/bsesoundfontrepo.hh
@@ -35,15 +35,12 @@ struct BseSoundFontRepoClass : BseSuperClass
 /* --- prototypes --- */
 void	       bse_sound_font_repo_list_all_presets   (BseSoundFontRepo *sfrepo,
 						       Bse::ItemSeq     &items);
-std::mutex&    bse_sound_font_repo_mutex              (BseSoundFontRepo *sfrepo);
 fluid_synth_t* bse_sound_font_repo_fluid_synth        (BseSoundFontRepo *sfrepo);
 
 namespace Bse {
 
 class SoundFontRepoImpl : public SuperImpl, public virtual SoundFontRepoIface {
 public:
-  std::mutex	     fluid_synth_mutex;
-
   std::vector<BseSoundFont *> sound_fonts;
 
   fluid_settings_t           *fluid_settings;

--- a/bse/bsesoundfontrepo.hh
+++ b/bse/bsesoundfontrepo.hh
@@ -37,44 +37,22 @@ void	       bse_sound_font_repo_list_all_presets   (BseSoundFontRepo *sfrepo,
 						       Bse::ItemSeq     &items);
 std::mutex&    bse_sound_font_repo_mutex              (BseSoundFontRepo *sfrepo);
 fluid_synth_t* bse_sound_font_repo_fluid_synth        (BseSoundFontRepo *sfrepo);
-int	       bse_sound_font_repo_add_osc            (BseSoundFontRepo *sfrepo,
-						       BseSoundFontOsc  *osc);
-void           bse_sound_font_repo_remove_osc         (BseSoundFontRepo *sfrepo,
-						       guint             osc_id);
 
 namespace Bse {
 
 class SoundFontRepoImpl : public SuperImpl, public virtual SoundFontRepoIface {
 public:
   std::mutex	     fluid_synth_mutex;
-  struct ChannelState {
-    std::vector<float>  values_left;
-    std::vector<float>  values_right;
-    int                 n_silence_samples;
-  };
-  std::vector<ChannelState> channel_state; /* [0..n_fluid_channels-1] */
 
-  struct Osc {
-    BseSoundFontOsc *osc;
-    guint            channel;
-  };
-  std::vector<Osc>            oscs;
   std::vector<BseSoundFont *> sound_fonts;
 
   fluid_settings_t           *fluid_settings;
   fluid_synth_t              *fluid_synth;
   guint                       fluid_mix_freq;
 
-  SfiRing                    *fluid_events;
-
-  guint                       n_fluid_channels;
-  guint64	              channel_values_tick_stamp;
-
-  int		              n_channel_oscs_active;	  /* SoundFontOscs with an active module in the engine thread */
-
 protected:
-
   virtual  ~SoundFontRepoImpl ();
+
 public:
   explicit      SoundFontRepoImpl (BseObject*);
   virtual Error load_file         (const String &file_name) override;

--- a/bse/bsesoundfontrepo.hh
+++ b/bse/bsesoundfontrepo.hh
@@ -45,7 +45,6 @@ public:
 
   fluid_settings_t           *fluid_settings;
   fluid_synth_t              *fluid_synth;
-  guint                       fluid_mix_freq;
 
 protected:
   virtual  ~SoundFontRepoImpl ();


### PR DESCRIPTION
This gets rid of all bse module locks in the fluid synth code, by using one fluid synth instance per track.

I observed that if we load the soundfont every time the user presses play, this can be slow (50ms to load fluid r2 * number of soundfont tracks), so this keeps the fluid synth instances even after the project stops playing, and re-uses the instances on play.

What this doesn't implement is changing the soundfont on a track while the project is playing (the gui doesn't let me do this anyway), but this could be implemented by preparing a new fluid_synth instance and exchanging it on the fly using an engine job.

I believe that this is the best/correct way to do it, better than https://github.com/tim-janik/beast/pull/85
