### PR TITLE
Bus properties ported to C++ - redone with APPLY_IDL_PROPERTY() macro

### DIFF
--- a/beast-gtk/bstbuseditor.cc
+++ b/beast-gtk/bstbuseditor.cc
@@ -89,8 +89,24 @@ bus_build_param (BstBusEditor *self,
                  const gchar  *editor,
                  const gchar  *label)
 {
-  GParamSpec *pspec = bse_proxy_get_pspec (self->item, property);
-  self->params = sfi_ring_prepend (self->params, bst_param_new_proxy (pspec, self->item));
+  GxkParam *gxk_param = nullptr;
+
+  /* aida property? */
+  Bse::BusH bus = Bse::BusH::__cast__ (bse_server.from_proxy (self->item));
+  const Bse::StringSeq meta = bus.find_prop (property);
+
+  GParamSpec *cxxpspec = Bse::pspec_from_key_value_list (property, meta);
+  if (cxxpspec)
+    gxk_param = bst_param_new_property (cxxpspec, bus);
+
+  if (!gxk_param)
+    {
+      /* proxy property */
+      auto pspec = bse_proxy_get_pspec (self->item, property);
+      gxk_param = bst_param_new_proxy (pspec, self->item);
+    }
+
+  self->params = sfi_ring_prepend (self->params, gxk_param);
   GtkWidget *ewidget = gxk_param_create_editor ((GxkParam*) self->params->data, editor);
   gxk_radget_add (self, area, ewidget);
   if (label)

--- a/beast-gtk/bstbuseditor.cc
+++ b/beast-gtk/bstbuseditor.cc
@@ -84,35 +84,36 @@ bus_editor_release_item (SfiProxy      item,
 
 static GxkParam *
 get_property_param (BstBusEditor *self,
+                    Bse::BusH     bus,
                     const gchar  *property)
 {
-  Bse::BusH bus = Bse::BusH::__cast__ (bse_server.from_proxy (self->item));
   const Bse::StringSeq kvlist = bus.find_prop (property);
 
-  GParamSpec *cxxpspec = Bse::pspec_from_key_value_list (property, kvlist);
-  if (cxxpspec)
-    return bst_param_new_property (cxxpspec, bus);
-
-  return nullptr;
+  if (!kvlist.empty())
+    {
+      /* aida property */
+      GParamSpec *cxxpspec = Bse::pspec_from_key_value_list (property, kvlist);
+      return bst_param_new_property (cxxpspec, bus);
+    }
+  else
+    {
+      /* proxy property */
+      auto pspec = bse_proxy_get_pspec (self->item, property);
+      return bst_param_new_proxy (pspec, self->item);
+    }
 }
 
 static GtkWidget*
 bus_build_param (BstBusEditor *self,
+                 Bse::BusH     bus,
                  const gchar  *property,
                  const gchar  *area,
                  const gchar  *editor,
                  const gchar  *label)
 {
-  GxkParam *gxk_param = get_property_param (self, property); /* aida property? */
-
-  if (!gxk_param)
-    {
-      /* proxy property */
-      auto pspec = bse_proxy_get_pspec (self->item, property);
-      gxk_param = bst_param_new_proxy (pspec, self->item);
-    }
-
+  GxkParam *gxk_param = get_property_param (self, bus, property);
   self->params = sfi_ring_prepend (self->params, gxk_param);
+
   GtkWidget *ewidget = gxk_param_create_editor ((GxkParam*) self->params->data, editor);
   gxk_radget_add (self, area, ewidget);
   if (label)
@@ -155,9 +156,10 @@ bst_bus_editor_set_bus (BstBusEditor *self,
                          "signal::release", bus_editor_release_item, self,
                          NULL);
       /* create and hook up volume params & scopes */
-      GxkParam *lvolume = get_property_param (self, "left_volume");
+      Bse::BusH bus = Bse::BusH::__cast__ (bse_server.from_proxy (self->item));
+      GxkParam *lvolume = get_property_param (self, bus, "left_volume");
       GtkWidget *lspinner = gxk_param_create_editor (lvolume, "spinner");
-      GxkParam *rvolume = get_property_param (self, "right_volume");
+      GxkParam *rvolume = get_property_param (self, bus, "right_volume");
       GtkWidget *rspinner = gxk_param_create_editor (rvolume, "spinner");
       BstDBMeter *dbmeter = (BstDBMeter*) gxk_radget_find (self, "db-meter");
       if (dbmeter)
@@ -180,12 +182,12 @@ bst_bus_editor_set_bus (BstBusEditor *self,
       self->params = sfi_ring_prepend (self->params, lvolume);
       self->params = sfi_ring_prepend (self->params, rvolume);
       /* create remaining params */
-      bus_build_param (self, "uname", "name-box", NULL, NULL);
-      bus_build_param (self, "inputs", "inputs-box", NULL, NULL);
-      bus_build_param (self, "mute", "toggle-box", "toggle+label", "M");
-      bus_build_param (self, "sync", "toggle-box", "toggle+label", "Y");
-      bus_build_param (self, "solo", "toggle-box", "toggle+label", "S");
-      bus_build_param (self, "outputs", "outputs-box", NULL, NULL);
+      bus_build_param (self, bus, "uname", "name-box", NULL, NULL);
+      bus_build_param (self, bus, "inputs", "inputs-box", NULL, NULL);
+      bus_build_param (self, bus, "mute", "toggle-box", "toggle+label", "M");
+      bus_build_param (self, bus, "sync", "toggle-box", "toggle+label", "Y");
+      bus_build_param (self, bus, "solo", "toggle-box", "toggle+label", "S");
+      bus_build_param (self, bus, "outputs", "outputs-box", NULL, NULL);
       /* update params */
       for (ring = self->params; ring; ring = sfi_ring_walk (ring, self->params))
         gxk_param_update ((GxkParam*) ring->data);

--- a/beast-gtk/bstbuseditor.cc
+++ b/beast-gtk/bstbuseditor.cc
@@ -150,7 +150,6 @@ bst_bus_editor_set_bus (BstBusEditor *self,
   if (self->item)
     {
       self->source = Bse::SourceH::__cast__ (bse_server.from_proxy (self->item));
-      GParamSpec *pspec;
       SfiRing *ring;
       bse_proxy_connect (self->item,
                          "signal::release", bus_editor_release_item, self,
@@ -158,8 +157,7 @@ bst_bus_editor_set_bus (BstBusEditor *self,
       /* create and hook up volume params & scopes */
       GxkParam *lvolume = get_property_param (self, "left_volume");
       GtkWidget *lspinner = gxk_param_create_editor (lvolume, "spinner");
-      pspec = bse_proxy_get_pspec (self->item, "right-volume");
-      GxkParam *rvolume = bst_param_new_proxy (pspec, self->item);
+      GxkParam *rvolume = get_property_param (self, "right_volume");
       GtkWidget *rspinner = gxk_param_create_editor (rvolume, "spinner");
       BstDBMeter *dbmeter = (BstDBMeter*) gxk_radget_find (self, "db-meter");
       if (dbmeter)

--- a/bse/bseapi.idl
+++ b/bse/bseapi.idl
@@ -986,12 +986,14 @@ interface Bus : SubSynth {
   // ItemSeq   inputs        = Object ("Input Signals", "Synthesis signals (from tracks and busses) used as bus input", GUI ":item-sequence");
   // ItemSeq   outputs       = Object ("Output Signals", "Mixer busses used as output for synthesis signals", GUI ":item-sequence");
   // CSynth    snet          = Object ("SNet", "Synthesis network used internally to implement effect stack", READWRITE ":skip-undo");
-  // bool      mute          = Bool   ("Mute", "Mute: turn off the bus volume",    STANDARD ":skip-default", FALSE);
   // bool      solo          = Bool   ("Solo", "Solo: mute all other busses",      STANDARD ":skip-default", FALSE);
   // bool      sync          = Bool   ("Sync", "Synchronize left and right volume", STANDARD ":skip-default", TRUE);
   // float64   left_volume   = Num    ("Left Volume",  "Volume adjustment in decibel of left bus channel",  STANDARD ":scale:db-volume");
   // float64   right_volume  = Num    ("Right Volume", "Volume adjustment in decibel of right bus channel", STANDARD ":scale:db-volume");
   // bool      master_output = Bool   ("Master Output", "", STORAGE ":skip-default", FALSE);
+  group _("Adjustments") {
+    bool mute = Bool (_("Mute"), _("Mute: turn off the bus volume"), STANDARD SKIP_DEFAULT, false);
+  };
 };
 
 /// Interface for Track and Part objects, as well as meta data for sequencing.

--- a/bse/bseapi.idl
+++ b/bse/bseapi.idl
@@ -976,6 +976,11 @@ sequence TrackPartSeq {
   TrackPart parts;
 };
 
+Const BUS_VOLUME_MIN = 1.58489319246111e-05; /* -96dB */
+Const BUS_VOLUME_MAX = 15.8489319246111;     /* +24dB */
+Const BUS_VOLUME_DEF = 1;
+Const BUS_VOLUME_STEP = 0.1;
+
 /// Interface for effect stacks and per-track audio signal routing to the master output.
 interface Bus : SubSynth {
   Error ensure_output    ();            ///< Ensure that a bus has an output connection.
@@ -993,6 +998,8 @@ interface Bus : SubSynth {
     bool mute = Bool (_("Mute"), _("Mute: turn off the bus volume"), STANDARD SKIP_DEFAULT, false);
     bool solo = Bool (_("Solo"), _("Solo: mute all other busses"), STANDARD SKIP_DEFAULT, false);
     bool sync = Bool (_("Sync"), _("Synchronize left and right volume"), STANDARD SKIP_DEFAULT, true);
+    float64 left_volume = Range (_("Left Volume"), _("Volume adjustment in decibel of left bus channel"), STANDARD ":scale:db-volume",
+                                 BUS_VOLUME_MIN, BUS_VOLUME_MAX, BUS_VOLUME_STEP, BUS_VOLUME_DEF);
   };
 };
 

--- a/bse/bseapi.idl
+++ b/bse/bseapi.idl
@@ -986,13 +986,13 @@ interface Bus : SubSynth {
   // ItemSeq   inputs        = Object ("Input Signals", "Synthesis signals (from tracks and busses) used as bus input", GUI ":item-sequence");
   // ItemSeq   outputs       = Object ("Output Signals", "Mixer busses used as output for synthesis signals", GUI ":item-sequence");
   // CSynth    snet          = Object ("SNet", "Synthesis network used internally to implement effect stack", READWRITE ":skip-undo");
-  // bool      solo          = Bool   ("Solo", "Solo: mute all other busses",      STANDARD ":skip-default", FALSE);
   // bool      sync          = Bool   ("Sync", "Synchronize left and right volume", STANDARD ":skip-default", TRUE);
   // float64   left_volume   = Num    ("Left Volume",  "Volume adjustment in decibel of left bus channel",  STANDARD ":scale:db-volume");
   // float64   right_volume  = Num    ("Right Volume", "Volume adjustment in decibel of right bus channel", STANDARD ":scale:db-volume");
   // bool      master_output = Bool   ("Master Output", "", STORAGE ":skip-default", FALSE);
   group _("Adjustments") {
     bool mute = Bool (_("Mute"), _("Mute: turn off the bus volume"), STANDARD SKIP_DEFAULT, false);
+    bool solo = Bool (_("Solo"), _("Solo: mute all other busses"), STANDARD SKIP_DEFAULT, false);
   };
 };
 

--- a/bse/bseapi.idl
+++ b/bse/bseapi.idl
@@ -986,13 +986,13 @@ interface Bus : SubSynth {
   // ItemSeq   inputs        = Object ("Input Signals", "Synthesis signals (from tracks and busses) used as bus input", GUI ":item-sequence");
   // ItemSeq   outputs       = Object ("Output Signals", "Mixer busses used as output for synthesis signals", GUI ":item-sequence");
   // CSynth    snet          = Object ("SNet", "Synthesis network used internally to implement effect stack", READWRITE ":skip-undo");
-  // bool      sync          = Bool   ("Sync", "Synchronize left and right volume", STANDARD ":skip-default", TRUE);
   // float64   left_volume   = Num    ("Left Volume",  "Volume adjustment in decibel of left bus channel",  STANDARD ":scale:db-volume");
   // float64   right_volume  = Num    ("Right Volume", "Volume adjustment in decibel of right bus channel", STANDARD ":scale:db-volume");
   // bool      master_output = Bool   ("Master Output", "", STORAGE ":skip-default", FALSE);
   group _("Adjustments") {
     bool mute = Bool (_("Mute"), _("Mute: turn off the bus volume"), STANDARD SKIP_DEFAULT, false);
     bool solo = Bool (_("Solo"), _("Solo: mute all other busses"), STANDARD SKIP_DEFAULT, false);
+    bool sync = Bool (_("Sync"), _("Synchronize left and right volume"), STANDARD SKIP_DEFAULT, true);
   };
 };
 

--- a/bse/bseapi.idl
+++ b/bse/bseapi.idl
@@ -991,15 +991,15 @@ interface Bus : SubSynth {
   // ItemSeq   inputs        = Object ("Input Signals", "Synthesis signals (from tracks and busses) used as bus input", GUI ":item-sequence");
   // ItemSeq   outputs       = Object ("Output Signals", "Mixer busses used as output for synthesis signals", GUI ":item-sequence");
   // CSynth    snet          = Object ("SNet", "Synthesis network used internally to implement effect stack", READWRITE ":skip-undo");
-  // float64   left_volume   = Num    ("Left Volume",  "Volume adjustment in decibel of left bus channel",  STANDARD ":scale:db-volume");
-  // float64   right_volume  = Num    ("Right Volume", "Volume adjustment in decibel of right bus channel", STANDARD ":scale:db-volume");
   // bool      master_output = Bool   ("Master Output", "", STORAGE ":skip-default", FALSE);
   group _("Adjustments") {
-    bool mute = Bool (_("Mute"), _("Mute: turn off the bus volume"), STANDARD SKIP_DEFAULT, false);
-    bool solo = Bool (_("Solo"), _("Solo: mute all other busses"), STANDARD SKIP_DEFAULT, false);
-    bool sync = Bool (_("Sync"), _("Synchronize left and right volume"), STANDARD SKIP_DEFAULT, true);
-    float64 left_volume = Range (_("Left Volume"), _("Volume adjustment in decibel of left bus channel"), STANDARD ":scale:db-volume",
-                                 BUS_VOLUME_MIN, BUS_VOLUME_MAX, BUS_VOLUME_STEP, BUS_VOLUME_DEF);
+    bool    mute         = Bool  (_("Mute"), _("Mute: turn off the bus volume"), STANDARD SKIP_DEFAULT, false);
+    bool    solo         = Bool  (_("Solo"), _("Solo: mute all other busses"), STANDARD SKIP_DEFAULT, false);
+    bool    sync         = Bool  (_("Sync"), _("Synchronize left and right volume"), STANDARD SKIP_DEFAULT, true);
+    float64 left_volume  = Range (_("Left Volume"), _("Volume adjustment in decibel of left bus channel"), STANDARD ":scale:db-volume",
+                                  BUS_VOLUME_MIN, BUS_VOLUME_MAX, BUS_VOLUME_STEP, BUS_VOLUME_DEF);
+    float64 right_volume = Range (_("Right Volume"), _("Volume adjustment in decibel of right bus channel"), STANDARD ":scale:db-volume",
+                                  BUS_VOLUME_MIN, BUS_VOLUME_MAX, BUS_VOLUME_STEP, BUS_VOLUME_DEF);
   };
 };
 

--- a/bse/bseapi.idl
+++ b/bse/bseapi.idl
@@ -991,7 +991,6 @@ interface Bus : SubSynth {
   // ItemSeq   inputs        = Object ("Input Signals", "Synthesis signals (from tracks and busses) used as bus input", GUI ":item-sequence");
   // ItemSeq   outputs       = Object ("Output Signals", "Mixer busses used as output for synthesis signals", GUI ":item-sequence");
   // CSynth    snet          = Object ("SNet", "Synthesis network used internally to implement effect stack", READWRITE ":skip-undo");
-  // bool      master_output = Bool   ("Master Output", "", STORAGE ":skip-default", FALSE);
   group _("Adjustments") {
     bool    mute         = Bool  (_("Mute"), _("Mute: turn off the bus volume"), STANDARD SKIP_DEFAULT, false);
     bool    solo         = Bool  (_("Solo"), _("Solo: mute all other busses"), STANDARD SKIP_DEFAULT, false);
@@ -1000,6 +999,9 @@ interface Bus : SubSynth {
                                   BUS_VOLUME_MIN, BUS_VOLUME_MAX, BUS_VOLUME_STEP, BUS_VOLUME_DEF);
     float64 right_volume = Range (_("Right Volume"), _("Volume adjustment in decibel of right bus channel"), STANDARD ":scale:db-volume",
                                   BUS_VOLUME_MIN, BUS_VOLUME_MAX, BUS_VOLUME_STEP, BUS_VOLUME_DEF);
+  };
+  group _("Internals") {
+    bool master_output = Bool (_("Master Output"), "", STORAGE SKIP_DEFAULT, false);
   };
 };
 

--- a/bse/bsebus.cc
+++ b/bse/bsebus.cc
@@ -23,7 +23,6 @@ enum
   PROP_INPUTS,
   PROP_OUTPUTS,
   PROP_SNET,
-  PROP_LEFT_VOLUME,
   PROP_RIGHT_VOLUME,
   PROP_MASTER_OUTPUT,
 };
@@ -387,21 +386,12 @@ bse_bus_set_property (GObject      *object,
     case PROP_SNET:
       g_object_set_property (G_OBJECT (self), "BseSubSynth::snet", value);
       break;
-    case PROP_LEFT_VOLUME:
-      self->left_volume = sfi_value_get_real (value);
-      if (self->synced)
-        {
-          self->right_volume = self->left_volume;
-          g_object_notify (G_OBJECT (self), "right-volume");
-        }
-      bus_volume_changed (self);
-      break;
     case PROP_RIGHT_VOLUME:
       self->right_volume = sfi_value_get_real (value);
       if (self->synced)
         {
           self->left_volume = self->right_volume;
-          g_object_notify (G_OBJECT (self), "left-volume");
+          self->as<Bse::BusImpl*>()->notify ("left_volume");
         }
       bus_volume_changed (self);
       break;
@@ -464,9 +454,6 @@ bse_bus_get_property (GObject    *object,
       break;
     case PROP_SNET:
       g_object_get_property (G_OBJECT (self), "BseSubSynth::snet", value);
-      break;
-    case PROP_LEFT_VOLUME:
-      sfi_value_set_real (value, self->synced ? center_volume (self->left_volume, self->right_volume) : self->left_volume);
       break;
     case PROP_RIGHT_VOLUME:
       sfi_value_set_real (value, self->synced ? center_volume (self->left_volume, self->right_volume) : self->right_volume);
@@ -880,10 +867,6 @@ bse_bus_class_init (BseBusClass *klass)
   source_class->context_connect = bse_bus_context_connect;
   source_class->reset = bse_bus_reset;
 
-  bse_object_class_add_param (object_class, _("Adjustments"), PROP_LEFT_VOLUME,
-			      sfi_pspec_real ("left-volume", _("Left Volume"), _("Volume adjustment in decibel of left bus channel"),
-                                              bse_db_to_factor (0), bse_db_to_factor (BSE_MINDB), bse_db_to_factor (+24),
-                                              bse_db_to_factor (0.1), SFI_PARAM_STANDARD ":scale:db-volume"));
   bse_object_class_add_param (object_class, _("Adjustments"), PROP_RIGHT_VOLUME,
 			      sfi_pspec_real ("right-volume", _("Right Volume"), _("Volume adjustment in decibel of right bus channel"),
                                               bse_db_to_factor (0), bse_db_to_factor (BSE_MINDB), bse_db_to_factor (+24),
@@ -1026,10 +1009,34 @@ BusImpl::sync (bool val)
         }
       bus_volume_changed (self);
 
-      g_object_notify (G_OBJECT (self), "left-volume");
+      notify ("left_volume");
       g_object_notify (G_OBJECT (self), "right-volume");
     }
   self->saved_sync = self->synced;
+}
+
+double
+BusImpl::left_volume() const
+{
+  BseBus *self = const_cast<BusImpl*> (this)->as<BseBus*>();
+
+  return self->synced ? center_volume (self->left_volume, self->right_volume) : self->left_volume;
+}
+
+void
+BusImpl::left_volume (double val)
+{
+  BseBus *self = as<BseBus*>();
+
+  if (APPLY_IDL_PROPERTY (self->left_volume, val))
+    {
+      if (self->synced)
+        {
+          self->right_volume = self->left_volume;
+          g_object_notify (G_OBJECT (self), "right-volume");
+        }
+      bus_volume_changed (self);
+    }
 }
 
 Error

--- a/bse/bsebus.cc
+++ b/bse/bsebus.cc
@@ -23,7 +23,6 @@ enum
   PROP_INPUTS,
   PROP_OUTPUTS,
   PROP_SNET,
-  PROP_RIGHT_VOLUME,
   PROP_MASTER_OUTPUT,
 };
 
@@ -386,15 +385,6 @@ bse_bus_set_property (GObject      *object,
     case PROP_SNET:
       g_object_set_property (G_OBJECT (self), "BseSubSynth::snet", value);
       break;
-    case PROP_RIGHT_VOLUME:
-      self->right_volume = sfi_value_get_real (value);
-      if (self->synced)
-        {
-          self->left_volume = self->right_volume;
-          self->as<Bse::BusImpl*>()->notify ("left_volume");
-        }
-      bus_volume_changed (self);
-      break;
     case PROP_MASTER_OUTPUT:
       parent = BSE_ITEM (self)->parent;
       if (BSE_IS_SONG (parent))
@@ -454,9 +444,6 @@ bse_bus_get_property (GObject    *object,
       break;
     case PROP_SNET:
       g_object_get_property (G_OBJECT (self), "BseSubSynth::snet", value);
-      break;
-    case PROP_RIGHT_VOLUME:
-      sfi_value_set_real (value, self->synced ? center_volume (self->left_volume, self->right_volume) : self->right_volume);
       break;
     case PROP_MASTER_OUTPUT:
       parent = BSE_ITEM (self)->parent;
@@ -867,10 +854,6 @@ bse_bus_class_init (BseBusClass *klass)
   source_class->context_connect = bse_bus_context_connect;
   source_class->reset = bse_bus_reset;
 
-  bse_object_class_add_param (object_class, _("Adjustments"), PROP_RIGHT_VOLUME,
-			      sfi_pspec_real ("right-volume", _("Right Volume"), _("Volume adjustment in decibel of right bus channel"),
-                                              bse_db_to_factor (0), bse_db_to_factor (BSE_MINDB), bse_db_to_factor (+24),
-                                              bse_db_to_factor (0.1), SFI_PARAM_STANDARD ":scale:db-volume"));
   bse_object_class_add_param (object_class, _("Signal Inputs"),
                               PROP_INPUTS,
                               /* SYNC: type partitions determine the order of displayed objects */
@@ -1010,7 +993,7 @@ BusImpl::sync (bool val)
       bus_volume_changed (self);
 
       notify ("left_volume");
-      g_object_notify (G_OBJECT (self), "right-volume");
+      notify ("right_volume");
     }
   self->saved_sync = self->synced;
 }
@@ -1033,7 +1016,31 @@ BusImpl::left_volume (double val)
       if (self->synced)
         {
           self->right_volume = self->left_volume;
-          g_object_notify (G_OBJECT (self), "right-volume");
+          notify ("right_volume");
+        }
+      bus_volume_changed (self);
+    }
+}
+
+double
+BusImpl::right_volume() const
+{
+  BseBus *self = const_cast<BusImpl*> (this)->as<BseBus*>();
+
+  return self->synced ? center_volume (self->left_volume, self->right_volume) : self->right_volume;
+}
+
+void
+BusImpl::right_volume (double val)
+{
+  BseBus *self = as<BseBus*>();
+
+  if (APPLY_IDL_PROPERTY (self->right_volume, val))
+    {
+      if (self->synced)
+        {
+          self->left_volume = self->right_volume;
+          notify ("left_volume");
         }
       bus_volume_changed (self);
     }

--- a/bse/bsebus.hh
+++ b/bse/bsebus.hh
@@ -86,6 +86,8 @@ public:
   virtual void      solo             (bool val) override;
   virtual bool      sync             () const override;
   virtual void      sync             (bool val) override;
+  virtual double    left_volume      () const override;
+  virtual void      left_volume      (double val) override;
   virtual Error     ensure_output    () override;
   virtual Error     connect_bus      (BusIface &bus) override;
   virtual Error     connect_track    (TrackIface &track) override;

--- a/bse/bsebus.hh
+++ b/bse/bsebus.hh
@@ -88,6 +88,8 @@ public:
   virtual void      sync             (bool val) override;
   virtual double    left_volume      () const override;
   virtual void      left_volume      (double val) override;
+  virtual double    right_volume     () const override;
+  virtual void      right_volume     (double val) override;
   virtual Error     ensure_output    () override;
   virtual Error     connect_bus      (BusIface &bus) override;
   virtual Error     connect_track    (TrackIface &track) override;

--- a/bse/bsebus.hh
+++ b/bse/bsebus.hh
@@ -19,8 +19,8 @@ struct BseBus : BseSubSynth {
   double        left_volume;
   double        right_volume;
   bool          muted;
-  guint         synced : 1;
-  guint         saved_sync : 1;
+  bool          synced;
+  bool          saved_sync;
   guint         solo_muted : 1;
   BseSource    *summation;
   BseSource    *vin;
@@ -84,6 +84,8 @@ public:
   virtual void      mute             (bool val) override;
   virtual bool      solo             () const override;
   virtual void      solo             (bool val) override;
+  virtual bool      sync             () const override;
+  virtual void      sync             (bool val) override;
   virtual Error     ensure_output    () override;
   virtual Error     connect_bus      (BusIface &bus) override;
   virtual Error     connect_track    (TrackIface &track) override;

--- a/bse/bsebus.hh
+++ b/bse/bsebus.hh
@@ -90,6 +90,8 @@ public:
   virtual void      left_volume      (double val) override;
   virtual double    right_volume     () const override;
   virtual void      right_volume     (double val) override;
+  virtual bool      master_output    () const override;
+  virtual void      master_output    (bool val) override;
   virtual Error     ensure_output    () override;
   virtual Error     connect_bus      (BusIface &bus) override;
   virtual Error     connect_track    (TrackIface &track) override;

--- a/bse/bsebus.hh
+++ b/bse/bsebus.hh
@@ -82,6 +82,8 @@ public:
   explicit          BusImpl          (BseObject*);
   virtual bool      mute             () const override;
   virtual void      mute             (bool val) override;
+  virtual bool      solo             () const override;
+  virtual void      solo             (bool val) override;
   virtual Error     ensure_output    () override;
   virtual Error     connect_bus      (BusIface &bus) override;
   virtual Error     connect_track    (TrackIface &track) override;

--- a/bse/bsebus.hh
+++ b/bse/bsebus.hh
@@ -18,7 +18,7 @@ struct BseBus : BseSubSynth {
   SfiRing      *inputs;
   double        left_volume;
   double        right_volume;
-  guint         muted : 1;
+  bool          muted;
   guint         synced : 1;
   guint         saved_sync : 1;
   guint         solo_muted : 1;
@@ -80,11 +80,13 @@ protected:
   virtual          ~BusImpl          ();
 public:
   explicit          BusImpl          (BseObject*);
-  virtual Error ensure_output    () override;
-  virtual Error connect_bus      (BusIface &bus) override;
-  virtual Error connect_track    (TrackIface &track) override;
-  virtual Error disconnect_bus   (BusIface &bus) override;
-  virtual Error disconnect_track (TrackIface &track) override;
+  virtual bool      mute             () const override;
+  virtual void      mute             (bool val) override;
+  virtual Error     ensure_output    () override;
+  virtual Error     connect_bus      (BusIface &bus) override;
+  virtual Error     connect_track    (TrackIface &track) override;
+  virtual Error     disconnect_bus   (BusIface &bus) override;
+  virtual Error     disconnect_track (TrackIface &track) override;
 };
 
 } // Bse

--- a/bse/bsesong.cc
+++ b/bse/bsesong.cc
@@ -497,8 +497,8 @@ bse_song_ensure_master (BseSong *self)
     {
       BseUndoStack *ustack = bse_item_undo_open (self, "Create Master");
       child = (BseSource*) bse_container_new_child_bname (BSE_CONTAINER (self), BSE_TYPE_BUS, master_bus_name(), NULL);
-      g_object_set (child, "master-output", TRUE, NULL); // not-undoable
       Bse::BusImpl *bus = child->as<Bse::BusImpl*>();
+      bus->master_output (true);
       Bse::ItemImpl::UndoDescriptor<Bse::BusImpl> bus_descriptor = this_->undo_descriptor (*bus);
       auto remove_bus_lambda = [bus_descriptor] (Bse::SongImpl &self, BseUndoStack *ustack) -> Bse::Error {
         Bse::BusImpl &bus = self.undo_resolve (bus_descriptor);
@@ -680,8 +680,7 @@ SongImpl::remove_bus (BusIface &bus_iface)
   return_unless (BSE_SOURCE_PREPARED (self) == false);
   BseItem *child = bus.as<BseItem*>();
   BseUndoStack *ustack = bse_item_undo_open (self, __func__);
-  // reset ::master-output property undoable
-  bse_item_set (child, "master-output", FALSE, NULL);
+  bus.master_output (false);
   // backup object references to undo stack
   bse_container_uncross_undoable (BSE_CONTAINER (self), child);
   // implement "undo" of bse_container_remove_backedup, i.e. redo


### PR DESCRIPTION
As requested, I went through all changes in https://github.com/tim-janik/beast/pull/78 and used APPLY_IDL_PROPERTY() where possible. In some cases it wasn't possible, so there are a few handwritten setters. I also avoid any fancy new features in the code  or ui, this is an 1:1 port.

This also fixes the C++ property loader code in bsestorage.cc so that make check passes.

From my perspective the only thing that could be controversial is that you used g_object_set(...property...value...) to avoid undo recording for some setter calls. I added a function to block undo manually so

```
  g_object_set (self, /* no undo */
               "sync", self->saved_sync,
                NULL);
```

now looks somewhat like this

```
  bus->block_property_undo(); 
  bus->sync (self->saved_sync);
  bus->unblock_property_undo();
```

This should work in the same way for setters that use APPLY_IDL_PROPERTY() and for hand-written setters that use push_property_undo(). If you have a better suggestion feel free to either change this after merging or letting me know how it should be done.