### PR TITLE
Track primitive properties ported to C++

### DIFF
--- a/beast-gtk/bsttrackview.cc
+++ b/beast-gtk/bsttrackview.cc
@@ -121,7 +121,6 @@ track_view_fill_value (BstItemView *iview,
   Bse::TrackH track = Bse::TrackH::__cast__ (item);
   switch (column)
     {
-      SfiInt vint;
       SfiProxy snet, wave, sound_font_preset;
     case COL_SEQID:
       sfi_value_take_string (value, g_strdup_format ("%03d", seqid));
@@ -133,8 +132,7 @@ track_view_fill_value (BstItemView *iview,
       g_value_set_boolean (value, !track.muted());
       break;
     case COL_VOICES:
-      bse_proxy_get (item.proxy_id(), "n_voices", &vint, NULL);
-      sfi_value_take_string (value, g_strdup_format ("%2d", vint));
+      sfi_value_take_string (value, g_strdup_format ("%2d", track.n_voices()));
       break;
     case COL_SYNTH:
       snet = 0;
@@ -454,9 +452,10 @@ track_view_voice_edited (BstTrackView *self,
       SfiProxy item = bst_item_view_get_proxy (BST_ITEM_VIEW (self), row);
       if (item)
 	{
+	  Bse::TrackH track = Bse::TrackH::__cast__ (bse_server.from_proxy (item));
 	  int i = strtol (text, NULL, 10);
 	  if (i > 0)
-	    bse_proxy_set (item, "n_voices", i, NULL);
+            track.n_voices (i);
 	}
     }
 }

--- a/beast-gtk/bsttrackview.cc
+++ b/beast-gtk/bsttrackview.cc
@@ -118,9 +118,9 @@ track_view_fill_value (BstItemView *iview,
   Bse::ItemH item = container.get_item (BST_ITEM_VIEW_GET_CLASS (self)->item_type, seqid);
   if (!item)
     return; // item is probably already destructed
+  Bse::TrackH track = Bse::TrackH::__cast__ (item);
   switch (column)
     {
-      gboolean vbool;
       SfiInt vint;
       SfiProxy snet, wave, sound_font_preset;
     case COL_SEQID:
@@ -130,8 +130,7 @@ track_view_fill_value (BstItemView *iview,
       g_value_set_string (value, item.get_name().c_str());
       break;
     case COL_MUTE:
-      bse_proxy_get (item.proxy_id(), "muted", &vbool, NULL);
-      g_value_set_boolean (value, !vbool);
+      g_value_set_boolean (value, !track.muted());
       break;
     case COL_VOICES:
       bse_proxy_get (item.proxy_id(), "n_voices", &vint, NULL);
@@ -436,11 +435,9 @@ track_view_mute_toggled (BstTrackView          *self,
       SfiProxy item = bst_item_view_get_proxy (BST_ITEM_VIEW (self), row);
       if (item)
 	{
-	  gboolean muted;
-	  bse_proxy_get (item, "muted", &muted, NULL);
-	  bse_proxy_set (item, "muted", !muted, NULL);
-	  bse_proxy_get (item, "muted", &muted, NULL);
-	  gtk_cell_renderer_toggle_set_active (tcell, !muted);
+	  Bse::TrackH track = Bse::TrackH::__cast__ (bse_server.from_proxy (item));
+	  track.muted (!track.muted());
+	  gtk_cell_renderer_toggle_set_active (tcell, !track.muted());
 	}
     }
 }

--- a/beast-gtk/bsttrackview.cc
+++ b/beast-gtk/bsttrackview.cc
@@ -164,8 +164,7 @@ track_view_fill_value (BstItemView *iview,
       }
       break;
     case COL_MIDI_CHANNEL:
-      bse_proxy_get (item.proxy_id(), "midi-channel", &vint, NULL);
-      sfi_value_take_string (value, g_strdup_format ("%2d", vint));
+      sfi_value_take_string (value, g_strdup_format ("%2d", track.midi_channel()));
       break;
     case COL_OUTPUTS:
       {
@@ -475,9 +474,10 @@ track_view_midi_channel_edited (BstTrackView *self,
       SfiProxy item = bst_item_view_get_proxy (BST_ITEM_VIEW (self), row);
       if (item)
 	{
+	  Bse::TrackH track = Bse::TrackH::__cast__ (bse_server.from_proxy (item));
 	  int i = strtol (text, NULL, 10);
 	  if (i >= 0)
-	    bse_proxy_set (item, "midi-channel", i, NULL);
+	    track.midi_channel (i);
 	}
     }
 }

--- a/beast-gtk/bsttrackview.hh
+++ b/beast-gtk/bsttrackview.hh
@@ -20,11 +20,13 @@ typedef	struct	_BstTrackView	   BstTrackView;
 typedef	struct	_BstTrackViewClass BstTrackViewClass;
 struct _BstTrackView
 {
-  BstItemView	          parent_object;
-  Bse::SongS              song;
-  BstTrackRoll	         *troll;
-  BstTrackRollController *tctrl;
-  GtkWidget		 *repeat_toggle;
+  BstItemView                     parent_object;
+  Bse::SongS                      song;
+  std::map<SfiProxy, Bse::TrackS> track_map;
+
+  BstTrackRoll                   *troll;
+  BstTrackRollController         *tctrl;
+  GtkWidget                      *repeat_toggle;
 };
 struct _BstTrackViewClass
 {

--- a/bse/bseapi.idl
+++ b/bse/bseapi.idl
@@ -926,6 +926,8 @@ interface SubSynth : Source {
 };
 
 /// Interface for sequencing information and links to Part objects.
+Const MIDI_MAX_CHANNEL = 99;
+
 interface Track : ContextMerger {
   SongTiming get_timing  (int32 tick);            ///< Retrieve song timing information at a specific tick.
   int32      insert_part (int32 tick, Part part); ///< Insert Part into Track at @a tick, returns the corresponding link id.
@@ -942,11 +944,15 @@ interface Track : ContextMerger {
   Source       get_output_source ();
 
   group _("Adjustments") {
-    bool muted = Bool (_("Muted"), _("Mute this track by ignoring it in the sequencer."), STANDARD SKIP_DEFAULT, false);
+    bool  muted = Bool (_("Muted"), _("Mute this track by ignoring it in the sequencer."), STANDARD SKIP_DEFAULT, false);
+  };
+  group _("MIDI Instrument") {
+    int32 midi_channel = Range (_("MIDI Channel"), _("Midi channel assigned to this track, 0 uses internal per-track channel"),
+                                GUI STORAGE ":scale:skip-default:unprepared",
+                                0, MIDI_MAX_CHANNEL, 1, 0);
   };
   // property CSynth snet;         ///< _("Synthesis network to be used as instrument.")
   // property Wave wave;           ///< _("Wave to be used as instrument.")
-  // property int32 midi_channel;  ///< _("Midi channel assigned to this track, 0 uses internal per-track channel.")
   // property int32 n_voices;      ///< _("Maximum number of voices for simultaneous playback.")
   // property CSynth pnet;         ///< _("Synthesis network to be used as postprocessor.")
   ItemSeq outputs;      ///< _("Mixer busses used as output for this track.")

--- a/bse/bseapi.idl
+++ b/bse/bseapi.idl
@@ -941,7 +941,9 @@ interface Track : ContextMerger {
   /// The output of this module is the merged result from all polyphonic voices and has all track specific alterations applied.
   Source       get_output_source ();
 
-  // property bool muted;          ///< _("Mute this track by ignoring it in the sequencer.")
+  group _("Adjustments") {
+    bool muted = Bool (_("Muted"), _("Mute this track by ignoring it in the sequencer."), STANDARD SKIP_DEFAULT, false);
+  };
   // property CSynth snet;         ///< _("Synthesis network to be used as instrument.")
   // property Wave wave;           ///< _("Wave to be used as instrument.")
   // property int32 midi_channel;  ///< _("Midi channel assigned to this track, 0 uses internal per-track channel.")

--- a/bse/bseapi.idl
+++ b/bse/bseapi.idl
@@ -948,12 +948,14 @@ interface Track : ContextMerger {
   };
   group _("MIDI Instrument") {
     int32 midi_channel = Range (_("MIDI Channel"), _("Midi channel assigned to this track, 0 uses internal per-track channel"),
-                                GUI STORAGE ":scale:skip-default:unprepared",
-                                0, MIDI_MAX_CHANNEL, 1, 0);
+                                GUI STORAGE ":scale:skip-default:unprepared", 0, MIDI_MAX_CHANNEL, 1, 0);
+  };
+  group _("Synth Input") {
+    int32 n_voices = Range (_("Max Voices"), _("Maximum number of voices for simultaneous playback"),
+			    GUI STORAGE ":scale:unprepared", 1, 256, 16, 1);
   };
   // property CSynth snet;         ///< _("Synthesis network to be used as instrument.")
   // property Wave wave;           ///< _("Wave to be used as instrument.")
-  // property int32 n_voices;      ///< _("Maximum number of voices for simultaneous playback.")
   // property CSynth pnet;         ///< _("Synthesis network to be used as postprocessor.")
   ItemSeq outputs;      ///< _("Mixer busses used as output for this track.")
 };

--- a/bse/bsesong.cc
+++ b/bse/bsesong.cc
@@ -1067,13 +1067,14 @@ bse_song_ensure_orphans_track_noundo (BseSong *self)
   for (SfiRing *ring = self->tracks_SL; ring; ring = sfi_ring_walk (ring, self->tracks_SL))
     {
       BseTrack *track = (BseTrack*) ring->data;
-      gboolean muted = FALSE;
-      g_object_get (track, "muted", &muted, NULL);
+      TrackImpl *trackimpl = track->as<TrackImpl*>();
+      bool muted = trackimpl->muted();
       if (muted && g_object_get_data ((GObject*) track, "BseSong-orphan-track") == bse_song_ensure_orphans_track_noundo) /* detect orphan-parts track */
         return track;
     }
   BseTrack *child = (BseTrack*) bse_container_new_child_bname (BSE_CONTAINER (self), BSE_TYPE_TRACK, orphans_track_name(), NULL);
-  g_object_set (child, "muted", TRUE, NULL); /* no undo */
+  TrackImpl *trackimpl = child->as<TrackImpl*>();
+  trackimpl->muted (true);
   g_object_set_data ((GObject*) child, "BseSong-orphan-track", (void*) bse_song_ensure_orphans_track_noundo); /* mark orphan-parts track */
   return child;
 }

--- a/bse/bsetrack.cc
+++ b/bse/bsetrack.cc
@@ -29,7 +29,6 @@
 
 enum {
   PROP_0,
-  PROP_MUTED,
   PROP_SNET,
   PROP_WAVE,
   PROP_SOUND_FONT_PRESET,
@@ -507,11 +506,6 @@ bse_track_set_property (GObject      *object,
   switch (param_id)
     {
       guint i;
-    case PROP_MUTED:
-      BSE_SEQUENCER_LOCK ();
-      self->muted_SL = sfi_value_get_bool (value);
-      BSE_SEQUENCER_UNLOCK ();
-      break;
     case PROP_SNET:
       if (!self->sub_synth || !BSE_SOURCE_PREPARED (self))
 	{
@@ -626,9 +620,6 @@ bse_track_get_property (GObject    *object,
     {
       BseIt3mSeq *iseq;
       SfiRing *ring;
-    case PROP_MUTED:
-      sfi_value_set_bool (value, self->muted_SL);
-      break;
     case PROP_SNET:
       bse_value_set_object (value, self->snet);
       break;
@@ -1108,10 +1099,6 @@ bse_track_class_init (BseTrackClass *klass)
 
   bse_source_class_inherit_channels (BSE_SOURCE_CLASS (klass));
 
-  bse_object_class_add_param (object_class, _("Adjustments"),
-			      PROP_MUTED,
-			      sfi_pspec_bool ("muted", _("Muted"), NULL,
-					      FALSE, SFI_PARAM_STANDARD ":skip-default"));
   bse_object_class_add_param (object_class, _("Synth Input"),
 			      PROP_SNET,
 			      bse_param_spec_object ("snet", _("Synthesizer"), _("Synthesis network to be used as instrument"),
@@ -1159,6 +1146,28 @@ TrackImpl::TrackImpl (BseObject *bobj) :
 
 TrackImpl::~TrackImpl ()
 {}
+
+bool
+TrackImpl::muted() const
+{
+  BseTrack *self = const_cast<TrackImpl*> (this)->as<BseTrack*>();
+
+  return self->muted_SL;
+}
+
+void
+TrackImpl::muted (bool muted)
+{
+  BseTrack *self = as<BseTrack*>();
+
+  bool value = self->muted_SL;
+  if (APPLY_IDL_PROPERTY (value, muted))
+    {
+      BSE_SEQUENCER_LOCK ();
+      self->muted_SL = value;
+      BSE_SEQUENCER_UNLOCK ();
+    }
+}
 
 SongTiming
 TrackImpl::get_timing (int tick)

--- a/bse/bsetrack.hh
+++ b/bse/bsetrack.hh
@@ -99,6 +99,8 @@ public:
   virtual SourceIfaceP get_output_source () override;
   virtual ItemSeq      outputs           () const override;
   virtual void         outputs           (const ItemSeq &newoutputs) override;
+  virtual bool         muted             () const override;
+  virtual void         muted             (bool val) override;
 };
 
 } // Bse

--- a/bse/bsetrack.hh
+++ b/bse/bsetrack.hh
@@ -101,6 +101,8 @@ public:
   virtual void         outputs           (const ItemSeq &newoutputs) override;
   virtual bool         muted             () const override;
   virtual void         muted             (bool val) override;
+  virtual int          midi_channel      () const override;
+  virtual void         midi_channel      (int val) override;
 };
 
 } // Bse

--- a/bse/bsetrack.hh
+++ b/bse/bsetrack.hh
@@ -103,6 +103,8 @@ public:
   virtual void         muted             (bool val) override;
   virtual int          midi_channel      () const override;
   virtual void         midi_channel      (int val) override;
+  virtual int          n_voices          () const override;
+  virtual void         n_voices          (int val) override;
 };
 
 } // Bse


### PR DESCRIPTION
I've ported all Track properties to C++ that do not contain object references. Two things are worth mentioning.

1. `Const MIDI_MAX_CHANNEL` - I declared this as constant, but maybe the definition must be moved elsewhere. It seems to be required in bsebasics.idl, too (there is a `// FIXME: MAX_MIDI_CHANNEL` in the `MidiChannelEvent` definition)
2. I didn't touch `"signal::property-notify::n-voices"` and similar signal code in bsttrackview.cc, I'm not sure what the C++ property equivalent would be