### PR TITLE
Port Super author/license to C++

### DIFF
--- a/bse/bseapi.idl
+++ b/bse/bseapi.idl
@@ -878,6 +878,8 @@ interface Container : Source {
 
 /// Base interface type for Item managers.
 interface Super : Container {
+  String author  = String (_("Author"), _("Person changing or creating this object"), STANDARD);
+  String license = String (_("License"), _("Copyright license applying to this object"), STANDARD);
 };
 
 /// A list of Super type objects.

--- a/bse/bseitem.hh
+++ b/bse/bseitem.hh
@@ -235,7 +235,7 @@ public:
       return false;
     T rvalue = cvalue;
     const StringVector kvlist = find_prop (propname);
-    if (std::is_integral<T>::value || std::is_floating_point<T>::value || std::is_enum<T>::value)
+    if constexpr (std::is_integral<T>::value || std::is_floating_point<T>::value || std::is_enum<T>::value)
       {
         if (!constrain_idl_property (rvalue, kvlist))
           return false;

--- a/bse/bsesuper.cc
+++ b/bse/bsesuper.cc
@@ -8,7 +8,6 @@
 enum
 {
   PARAM_0,
-  PARAM_COPYRIGHT,
   PARAM_CREATION_TIME,
   PARAM_MOD_TIME
 };
@@ -16,8 +15,6 @@ enum
 
 /* --- variables --- */
 static GTypeClass	*parent_class = NULL;
-static GQuark		 quark_author = 0;
-static GQuark		 quark_license = 0;
 static GSList		*bse_super_objects = NULL;
 
 
@@ -56,13 +53,6 @@ bse_super_set_property (GObject      *object,
   BseSuper *super = BSE_SUPER (object);
   switch (param_id)
     {
-    case PARAM_COPYRIGHT:
-      if (g_object_get_qdata ((GObject*) super, quark_license) == NULL)
-        g_object_set_qdata_full ((GObject*) super, quark_license,
-                                 g_strdup (g_value_get_string (value)),
-                                 g_free);
-      g_object_notify ((GObject*) super, "license");
-      break;
     case PARAM_MOD_TIME:
       super->mod_time = MAX (super->creation_time, sfi_value_get_time (value));
       break;
@@ -140,8 +130,6 @@ bse_super_class_init (BseSuperClass *klass)
   // BseSourceClass *source_class = BSE_SOURCE_CLASS (klass);
 
   parent_class = (GTypeClass*) g_type_class_peek_parent (klass);
-  quark_author = g_quark_from_static_string ("author");
-  quark_license = g_quark_from_static_string ("license");
 
   gobject_class->set_property = bse_super_set_property;
   gobject_class->get_property = bse_super_get_property;
@@ -152,9 +140,6 @@ bse_super_class_init (BseSuperClass *klass)
   klass->modified = super_modified;
   klass->compat_finish = super_compat_finish;
 
-  bse_object_class_add_param (object_class, NULL,
-			      PARAM_COPYRIGHT,
-			      sfi_pspec_string ("copyright", NULL, NULL, NULL, "w")); // COMPAT-FIXME: remove around 0.7.0
   bse_object_class_add_param (object_class, "Time Stamps",
 			      PARAM_CREATION_TIME,
 			      sfi_pspec_time ("creation_time", _("Creation Time"), NULL,

--- a/bse/bsesuper.hh
+++ b/bse/bsesuper.hh
@@ -43,9 +43,16 @@ namespace Bse {
 
 class SuperImpl : public ContainerImpl, public virtual SuperIface {
 protected:
+  String             author_;
+  String             license_;
   virtual           ~SuperImpl         ();
 public:
   explicit           SuperImpl         (BseObject*);
+
+  virtual String     author            () const override;
+  virtual void       author            (const String& val) override;
+  virtual String     license           () const override;
+  virtual void       license           (const String& val) override;
 };
 
 } // Bse


### PR DESCRIPTION
This is the first string property port that uses the `APPLY_IDL_PROPERTY` macro. Since there is no version of `constrain_idl_property` for strings, your code didn't compile when instantiated with strings. So I used C++17 `if constexpr` for checking for the type which compiles now. This means strings are not constrained (and all other types). If that wasn't your intention when writing the code, probably a String specialization of `constrain_idl_property` would be better.

I preserved the quark setting/getting (no idea why it is done this way in the first place). However I wonder if SuperImpl shouldn't simply have two string members, one for author and one for license.