### PR TITLE
Property ports for MidiSynth

### DIFF
--- a/bse/bseapi.idl
+++ b/bse/bseapi.idl
@@ -1138,8 +1138,9 @@ interface MidiSynth : SNet {
                                 1, 256, 1, 16);
   };
   group _("Adjustments") {
-    float64 volume_f  = Range (_("Master [float]"), "", STORAGE, 0, 15.8489319246111 /* +24dB */, 0.1, 1.0);
-    float64 volume_dB = Range (_("Master [dB]"), "", GUI ":dial", MIN_VOLUME_DB, MAX_VOLUME_DB, 0.1, 0);
+    float64 volume_f    = Range (_("Master [float]"), "", STORAGE, 0, 15.8489319246111 /* +24dB */, 0.1, 1.0);
+    float64 volume_dB   = Range (_("Master [dB]"), "", GUI ":dial", MIN_VOLUME_DB, MAX_VOLUME_DB, 0.1, 0);
+    int32   volume_perc = Range (_("Master [%]"), "", GUI ":dial", 0, 1584 /* +24dB */, 1, 100);
   };
 };
 

--- a/bse/bseapi.idl
+++ b/bse/bseapi.idl
@@ -1125,6 +1125,8 @@ interface MidiNotifier : Item {
 
 /// Interface for MIDI synthesis networks.
 Const MAX_MIDI_CHANNEL = 99;
+Const MIN_VOLUME_DB    = -144;
+Const MAX_VOLUME_DB    = 24;
 
 interface MidiSynth : SNet {
   group _("MIDI Instrument") {
@@ -1136,9 +1138,8 @@ interface MidiSynth : SNet {
                                 1, 256, 1, 16);
   };
   group _("Adjustments") {
-    float64 volume_f = Range (_("Master [float]"), _("Master volume as factor"),
-                              STORAGE,
-                              0, 15.8489319246111 /* +24dB */, 0.1, 1.0);
+    float64 volume_f  = Range (_("Master [float]"), "", STORAGE, 0, 15.8489319246111 /* +24dB */, 0.1, 1.0);
+    float64 volume_dB = Range (_("Master [dB]"), "", GUI ":dial", MIN_VOLUME_DB, MAX_VOLUME_DB, 0.1, 0);
   };
 };
 

--- a/bse/bseapi.idl
+++ b/bse/bseapi.idl
@@ -1135,6 +1135,11 @@ interface MidiSynth : SNet {
                                 STANDARD ":scale",
                                 1, 256, 1, 16);
   };
+  group _("Adjustments") {
+    float64 volume_f = Range (_("Master [float]"), _("Master volume as factor"),
+                              STORAGE,
+                              0, 15.8489319246111 /* +24dB */, 0.1, 1.0);
+  };
 };
 
 /// Enumeration describing the current activation and playback state of a project.

--- a/bse/bseapi.idl
+++ b/bse/bseapi.idl
@@ -1131,6 +1131,9 @@ interface MidiSynth : SNet {
     int32 midi_channel = Range (_("MIDI Channel"), _("Midi channel assigned to this midi synthesizer"),
                                 STANDARD ":scale:skip-default:unprepared",
                                 1, MAX_MIDI_CHANNEL, 1, 1);
+    int32 n_voices     = Range (_("Max Voices"), _("Maximum number of voices for simultaneous playback"),
+                                STANDARD ":scale",
+                                1, 256, 1, 16);
   };
 };
 

--- a/bse/bseapi.idl
+++ b/bse/bseapi.idl
@@ -1124,7 +1124,14 @@ interface MidiNotifier : Item {
 };
 
 /// Interface for MIDI synthesis networks.
+Const MAX_MIDI_CHANNEL = 99;
+
 interface MidiSynth : SNet {
+  group _("MIDI Instrument") {
+    int32 midi_channel = Range (_("MIDI Channel"), _("Midi channel assigned to this midi synthesizer"),
+                                STANDARD ":scale:skip-default:unprepared",
+                                1, MAX_MIDI_CHANNEL, 1, 1);
+  };
 };
 
 /// Enumeration describing the current activation and playback state of a project.

--- a/bse/bsemidisynth.cc
+++ b/bse/bsemidisynth.cc
@@ -80,7 +80,6 @@ bse_midi_synth_init (BseMidiSynth *self)
   self->set_flag (BSE_SUPER_FLAG_NEEDS_CONTEXT);
   self->midi_channel_id = 1;
   self->n_voices = 16;
-  self->volume_factor = bse_db_to_factor (0);
 }
 
 static void
@@ -429,10 +428,10 @@ MidiSynthImpl::volume_f (double val)
 {
   BseMidiSynth *self = as<BseMidiSynth*>();
 
-  if (APPLY_IDL_PROPERTY (self->volume_factor, val))
+  if (APPLY_IDL_PROPERTY (volume_factor_, val))
     {
       g_object_set (self->output, /* no undo */
-                    "master_volume_f", self->volume_factor,
+                    "master_volume_f", volume_factor_,
                     NULL);
       notify ("volume_dB");
       notify ("volume_perc");
@@ -442,9 +441,7 @@ MidiSynthImpl::volume_f (double val)
 double
 MidiSynthImpl::volume_f() const
 {
-  BseMidiSynth *self = const_cast<MidiSynthImpl*> (this)->as<BseMidiSynth*>();
-
-  return self->volume_factor;
+  return volume_factor_;
 }
 
 void
@@ -455,9 +452,9 @@ MidiSynthImpl::volume_dB (double volume)
   double value = volume_dB();
   if (APPLY_IDL_PROPERTY (value, volume))
     {
-      self->volume_factor = bse_db_to_factor (value);
+      volume_factor_ = bse_db_to_factor (value);
       g_object_set (self->output, /* no undo */
-                    "master_volume_f", self->volume_factor,
+                    "master_volume_f", volume_factor_,
                     NULL);
       notify ("volume_f");
       notify ("volume_perc");
@@ -467,9 +464,7 @@ MidiSynthImpl::volume_dB (double volume)
 double
 MidiSynthImpl::volume_dB() const
 {
-  BseMidiSynth *self = const_cast<MidiSynthImpl*> (this)->as<BseMidiSynth*>();
-
-  return bse_db_from_factor (self->volume_factor, BSE_MIN_VOLUME_dB);
+  return bse_db_from_factor (volume_factor_, BSE_MIN_VOLUME_dB);
 }
 
 
@@ -481,9 +476,9 @@ MidiSynthImpl::volume_perc (int volume)
   int value = volume_perc();
   if (APPLY_IDL_PROPERTY (value, volume))
     {
-      self->volume_factor = value / 100.0;
+      volume_factor_ = value / 100.0;
       g_object_set (self->output, /* no undo */
-                    "master_volume_f", self->volume_factor,
+                    "master_volume_f", volume_factor_,
                     NULL);
       notify ("volume_f");
       notify ("volume_dB");
@@ -493,9 +488,7 @@ MidiSynthImpl::volume_perc (int volume)
 int
 MidiSynthImpl::volume_perc() const
 {
-  BseMidiSynth *self = const_cast<MidiSynthImpl*> (this)->as<BseMidiSynth*>();
-
-  return self->volume_factor * 100.0 + 0.5;
+  return volume_factor_ * 100.0 + 0.5;
 }
 
 }

--- a/bse/bsemidisynth.cc
+++ b/bse/bsemidisynth.cc
@@ -20,7 +20,6 @@ enum
   PROP_0,
   PROP_SNET,
   PROP_PNET,
-  PROP_VOLUME_f,
   PROP_VOLUME_dB,
   PROP_VOLUME_PERC,
 };
@@ -164,6 +163,7 @@ bse_midi_synth_set_property (GObject      *object,
 			     GParamSpec   *pspec)
 {
   BseMidiSynth *self = BSE_MIDI_SYNTH (object);
+  auto impl = self->as<Bse::MidiSynthImpl*>();
   switch (param_id)
     {
     case PROP_SNET:
@@ -207,20 +207,12 @@ bse_midi_synth_set_property (GObject      *object,
                           NULL);
         }
       break;
-    case PROP_VOLUME_f:
-      self->volume_factor = sfi_value_get_real (value);
-      g_object_set (self->output, /* no undo */
-                    "master_volume_f", self->volume_factor,
-                    NULL);
-      g_object_notify ((GObject*) self, "volume_dB");
-      g_object_notify ((GObject*) self, "volume_perc");
-      break;
     case PROP_VOLUME_dB:
       self->volume_factor = bse_db_to_factor (sfi_value_get_real (value));
       g_object_set (self->output, /* no undo */
                     "master_volume_f", self->volume_factor,
                     NULL);
-      g_object_notify ((GObject*) self, "volume_f");
+      impl->notify ("volume_f");
       g_object_notify ((GObject*) self, "volume_perc");
       break;
     case PROP_VOLUME_PERC:
@@ -228,7 +220,7 @@ bse_midi_synth_set_property (GObject      *object,
       g_object_set (self->output, /* no undo */
                     "master_volume_f", self->volume_factor,
                     NULL);
-      g_object_notify ((GObject*) self, "volume_f");
+      impl->notify ("volume_f");
       g_object_notify ((GObject*) self, "volume_dB");
       break;
     default:
@@ -251,9 +243,6 @@ bse_midi_synth_get_property (GObject    *object,
       break;
     case PROP_PNET:
       bse_value_set_object (value, self->pnet);
-      break;
-    case PROP_VOLUME_f:
-      sfi_value_set_real (value, self->volume_factor);
       break;
     case PROP_VOLUME_dB:
       sfi_value_set_real (value, bse_db_from_factor (self->volume_factor, BSE_MIN_VOLUME_dB));
@@ -333,12 +322,6 @@ bse_midi_synth_class_init (BseMidiSynthClass *klass)
                               bse_param_spec_object ("pnet", _("Postprocessor"), _("Synthesis network to be used as postprocessor"),
                                                      BSE_TYPE_CSYNTH,
                                                      SFI_PARAM_STANDARD ":unprepared"));
-  bse_object_class_add_param (object_class, _("Adjustments"),
-			      PROP_VOLUME_f,
-			      sfi_pspec_real ("volume_f", _("Master [float]"), NULL,
-					      bse_db_to_factor (0),
-					      0, bse_db_to_factor (BSE_MAX_VOLUME_dB), 0.1,
-					      SFI_PARAM_STORAGE));
   bse_object_class_add_param (object_class, _("Adjustments"),
 			      PROP_VOLUME_dB,
 			      sfi_pspec_real ("volume_dB", _("Master [dB]"), NULL,
@@ -479,4 +462,27 @@ MidiSynthImpl::n_voices() const
   return self->n_voices;
 }
 
-} // Bse
+void
+MidiSynthImpl::volume_f (double val)
+{
+  BseMidiSynth *self = as<BseMidiSynth*>();
+
+  if (APPLY_IDL_PROPERTY (self->volume_factor, val))
+    {
+      g_object_set (self->output, /* no undo */
+                    "master_volume_f", self->volume_factor,
+                    NULL);
+      g_object_notify ((GObject*) self, "volume_dB");
+      g_object_notify ((GObject*) self, "volume_perc");
+    }
+}
+
+double
+MidiSynthImpl::volume_f() const
+{
+  BseMidiSynth *self = const_cast<MidiSynthImpl*> (this)->as<BseMidiSynth*>();
+
+  return self->volume_factor;
+}
+
+}

--- a/bse/bsemidisynth.cc
+++ b/bse/bsemidisynth.cc
@@ -18,7 +18,6 @@
 enum
 {
   PROP_0,
-  PROP_N_VOICES,
   PROP_SNET,
   PROP_PNET,
   PROP_VOLUME_f,
@@ -208,10 +207,6 @@ bse_midi_synth_set_property (GObject      *object,
                           NULL);
         }
       break;
-    case PROP_N_VOICES:
-      if (!BSE_OBJECT_IS_LOCKED (self))
-	self->n_voices = sfi_value_get_int (value);
-      break;
     case PROP_VOLUME_f:
       self->volume_factor = sfi_value_get_real (value);
       g_object_set (self->output, /* no undo */
@@ -256,9 +251,6 @@ bse_midi_synth_get_property (GObject    *object,
       break;
     case PROP_PNET:
       bse_value_set_object (value, self->pnet);
-      break;
-    case PROP_N_VOICES:
-      sfi_value_set_int (value, self->n_voices);
       break;
     case PROP_VOLUME_f:
       sfi_value_set_real (value, self->volume_factor);
@@ -332,11 +324,6 @@ bse_midi_synth_class_init (BseMidiSynthClass *klass)
   source_class->context_create = bse_midi_synth_context_create;
   source_class->context_dismiss = bse_midi_synth_context_dismiss;
 
-  bse_object_class_add_param (object_class, _("MIDI Instrument"),
-			      PROP_N_VOICES,
-			      sfi_pspec_int ("n_voices", _("Max Voices"), _("Maximum number of voices for simultaneous playback"),
-					     16, 1, 256, 1,
-					     SFI_PARAM_GUI SFI_PARAM_STORAGE ":scale"));
   bse_object_class_add_param (object_class, _("MIDI Instrument"),
 			      PROP_SNET,
 			      bse_param_spec_object ("snet", _("Synthesizer"), _("Synthesis network to be used as MIDI instrument"),
@@ -472,6 +459,24 @@ MidiSynthImpl::midi_channel() const
   BseMidiSynth *self = const_cast<MidiSynthImpl*> (this)->as<BseMidiSynth*>();
 
   return self->midi_channel_id;
+}
+
+void
+MidiSynthImpl::n_voices (int voices)
+{
+  BseMidiSynth *self = as<BseMidiSynth*>();
+
+  int value = self->n_voices;
+  if (APPLY_IDL_PROPERTY (value, voices) && !BSE_OBJECT_IS_LOCKED (self))
+    self->n_voices = value;
+}
+
+int
+MidiSynthImpl::n_voices() const
+{
+  BseMidiSynth *self = const_cast<MidiSynthImpl*> (this)->as<BseMidiSynth*>();
+
+  return self->n_voices;
 }
 
 } // Bse

--- a/bse/bsemidisynth.hh
+++ b/bse/bsemidisynth.hh
@@ -45,6 +45,8 @@ public:
   virtual void    volume_f       (double val) override;
   virtual double  volume_dB      () const override;
   virtual void    volume_dB      (double val) override;
+  virtual int     volume_perc    () const override;
+  virtual void    volume_perc    (int val) override;
 };
 
 } // Bse

--- a/bse/bsemidisynth.hh
+++ b/bse/bsemidisynth.hh
@@ -39,6 +39,8 @@ public:
   explicit     MidiSynthImpl  (BseObject*);
   virtual int  midi_channel      () const override;
   virtual void midi_channel      (int val) override;
+  virtual int  n_voices          () const override;
+  virtual void n_voices          (int val) override;
 };
 
 } // Bse

--- a/bse/bsemidisynth.hh
+++ b/bse/bsemidisynth.hh
@@ -16,7 +16,6 @@
 struct BseMidiSynth : BseSNet {
   guint		 midi_channel_id;
   guint		 n_voices;
-  double	 volume_factor;         /* 1-based factor */
   BseSNet       *snet;
   BseSNet       *pnet;
   BseSource	*voice_input;
@@ -33,6 +32,8 @@ namespace Bse {
 
 class MidiSynthImpl : public SNetImpl, public virtual MidiSynthIface {
 protected:
+  double	  volume_factor_ = 1.0;         /* 1-based factor */
+
   virtual        ~MidiSynthImpl  ();
   virtual void    post_init      () override;
 public:

--- a/bse/bsemidisynth.hh
+++ b/bse/bsemidisynth.hh
@@ -43,6 +43,8 @@ public:
   virtual void    n_voices       (int val) override;
   virtual double  volume_f       () const override;
   virtual void    volume_f       (double val) override;
+  virtual double  volume_dB      () const override;
+  virtual void    volume_dB      (double val) override;
 };
 
 } // Bse

--- a/bse/bsemidisynth.hh
+++ b/bse/bsemidisynth.hh
@@ -37,6 +37,8 @@ protected:
   virtual void post_init      () override;
 public:
   explicit     MidiSynthImpl  (BseObject*);
+  virtual int  midi_channel      () const override;
+  virtual void midi_channel      (int val) override;
 };
 
 } // Bse

--- a/bse/bsemidisynth.hh
+++ b/bse/bsemidisynth.hh
@@ -16,7 +16,7 @@
 struct BseMidiSynth : BseSNet {
   guint		 midi_channel_id;
   guint		 n_voices;
-  gfloat	 volume_factor;         /* 1-based factor */
+  double	 volume_factor;         /* 1-based factor */
   BseSNet       *snet;
   BseSNet       *pnet;
   BseSource	*voice_input;
@@ -33,14 +33,16 @@ namespace Bse {
 
 class MidiSynthImpl : public SNetImpl, public virtual MidiSynthIface {
 protected:
-  virtual     ~MidiSynthImpl  ();
-  virtual void post_init      () override;
+  virtual        ~MidiSynthImpl  ();
+  virtual void    post_init      () override;
 public:
-  explicit     MidiSynthImpl  (BseObject*);
-  virtual int  midi_channel      () const override;
-  virtual void midi_channel      (int val) override;
-  virtual int  n_voices          () const override;
-  virtual void n_voices          (int val) override;
+  explicit        MidiSynthImpl  (BseObject*);
+  virtual int     midi_channel   () const override;
+  virtual void    midi_channel   (int val) override;
+  virtual int     n_voices       () const override;
+  virtual void    n_voices       (int val) override;
+  virtual double  volume_f       () const override;
+  virtual void    volume_f       (double val) override;
 };
 
 } // Bse


### PR DESCRIPTION
This ports all properties of the MidiSynth to C++ (except for object properties SNet/PNet).

I had to fix a bug in BsePcmOutput (first commit), because setting the volume on the output object had no effect, but I wanted to test my code.

To have 1:1 the same ranges, I introduced constants for BSE_MIN|MAX_VOLUME_dB, but maybe this should just be hardcoded to -96 / 24. For the new max midi channel constant I think a constant should be used (maybe moved up to the other constants).

I noticed that some property idl constants don't combine properly. If you write Range (... GUI STORAGE ...), this expands to "r:w:G" "r:w:S" - so instead of getting a "G" hint, you get a "Gr" hint. Here I used STANDARD as ported property type, to work around the issue,which has both "G" and "S" hints. Not sure what is intended here, but adding ":" at the beginning and end of each property constant would allow using both versions for a GUI & STORAGE property.