### PR TITLE
Properties that have Objects as value are currently not portable to C++

### DIFF
--- a/bse/bseapi.idl
+++ b/bse/bseapi.idl
@@ -1023,8 +1023,11 @@ interface Song : SNet {
   void       synthesize_note         (Track track, int32 duration, int32 note, int32 fine_tune, float64 velocity);
   // signal void   pointer_changed (int32 a);
   // group _("MIDI Instrument") {
-  // CSynth  pnet          = Object ("Postprocessor", "Synthesis network to be used as postprocessor", STANDARD);
+  // CSynth  pnet          = ("Postprocessor", "Synthesis network to be used as postprocessor", STANDARD);
   // };
+  group _("MIDI Instrument") {
+    CSynth pnet = Object (_("Postprocessor"), _("Synthesis network to be used as postprocessor"), STANDARD ":unprepared");
+  };
   group _("Timing") {
     int32   tpqn          = Range (_("TPQN"), _("Number of ticks per quarter note"), STANDARD_RDONLY, 384, 384, 0, 384);
     int32   numerator     = Range (_("Numerator"), _("Measure numerator"), STANDARD, 1, 256, 1, 4);

--- a/bse/bsesong.cc
+++ b/bse/bsesong.cc
@@ -20,7 +20,6 @@
 enum
 {
   PROP_0,
-  PROP_PNET,
 };
 
 
@@ -109,11 +108,13 @@ bse_song_get_candidates (BseItem *item, uint param_id, Bse::PropertyCandidates &
   BseSong *self = BSE_SONG (item);
   switch (param_id)
     {
+#if 0
     case PROP_PNET:
       pc.label = _("Available Postprocessors");
       pc.tooltip = _("List of available synthesis networks to choose a postprocessor from");
       bse_item_gather_items_typed (item, pc.items, BSE_TYPE_CSYNTH, BSE_TYPE_PROJECT, FALSE);
       break;
+#endif
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (self, param_id, pspec);
       break;
@@ -137,6 +138,7 @@ bse_song_set_property (GObject      *object,
   BseSong *self = BSE_SONG (object);
   switch (param_id)
     {
+#if 0
     case PROP_PNET:
       if (!self->postprocess || !BSE_SOURCE_PREPARED (self->postprocess))
         {
@@ -158,6 +160,7 @@ bse_song_set_property (GObject      *object,
                           NULL);
         }
       break;
+#endif
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, param_id, pspec);
       break;
@@ -173,9 +176,11 @@ bse_song_get_property (GObject     *object,
   BseSong *self = BSE_SONG (object);
   switch (param_id)
     {
+#if 0
     case PROP_PNET:
       bse_value_set_object (value, self->pnet);
       break;
+#endif
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, param_id, pspec);
       break;
@@ -604,11 +609,6 @@ bse_song_class_init (BseSongClass *klass)
   super_class->compat_finish = bse_song_compat_finish;
 
   bse_song_timing_get_default (&timing);
-
-  bse_object_class_add_param (object_class, _("MIDI Instrument"),
-                              PROP_PNET,
-                              bse_param_spec_object ("pnet", _("Postprocessor"), _("Synthesis network to be used as postprocessor"),
-                                                     BSE_TYPE_CSYNTH, SFI_PARAM_STANDARD ":unprepared"));
 
   signal_pointer_changed = bse_object_class_add_signal (object_class, "pointer-changed",
 							G_TYPE_NONE, 1, SFI_TYPE_INT);


### PR DESCRIPTION
As discussed previously, I created one example what happens if I try to port a property that contains an Object to C++. I choose Song postprocessing network as example.

```
stefan@quadcorn:~/src/ghbeast (object-pport-error % u=)$ make -j1
  MODE     debug
  CHECK    Configuration dependencies...
  GEN      out/config-cache.mk
  KEEP     out/config-stamps.sha256
  MODE     debug
  GEN      out/bse/bseapi_interfaces.hh out/bse/bseapi_interfaces.cc out/bse/bseapi_handles.hh out/bse/bseapi_handles.cc
bse/bseapi.idl:1029: error: invalid type definition: = Object (_("Postprocessor"), _("Synthesis network to be used as postprocessor"), "r:w:S:G:unprepared")
bse/Makefile.mk:390: recipe for target '/.../·out∕bse∕bseapi_interfaces.hh·out∕bse∕bseapi_interfaces.cc·out∕bse∕bseapi_handles.hh·out∕bse∕bseapi_handles.cc·.INTERMEDIATE' failed
make: *** [/.../·out∕bse∕bseapi_interfaces.hh·out∕bse∕bseapi_interfaces.cc·out∕bse∕bseapi_handles.hh·out∕bse∕bseapi_handles.cc·.INTERMEDIATE] Error 7
```

It seems aida doesn't recognize `Object` as valid type here.