### PR TITLE
Part properties ported to C++

### DIFF
--- a/beast-gtk/bsteventroll.cc
+++ b/beast-gtk/bsteventroll.cc
@@ -570,9 +570,8 @@ event_roll_handle_drag (GxkScrollCanvas     *scc,
 static void
 event_roll_range_changed (BstEventRoll *self)
 {
-  guint max_ticks;
-  bse_proxy_get (self->part.proxy_id(), "last-tick", &max_ticks, NULL);
-  bst_event_roll_hsetup (self, self->ppqn, self->qnpt, self->max_ticks, self->hzoom);
+  guint max_ticks = self->part.last_tick();
+  bst_event_roll_hsetup (self, self->ppqn, self->qnpt, max_ticks, self->hzoom);
 }
 
 static void
@@ -611,8 +610,8 @@ bst_event_roll_set_part (BstEventRoll *self, Bse::PartH part)
   if (self->part)
     {
       self->part.on ("dispose", [self] () { bst_event_roll_set_part (self); });
+      self->part.on ("notify:last_tick", [self]() { event_roll_range_changed (self); });
       bse_proxy_connect (self->part.proxy_id(),
-                         "swapped-signal::property-notify::last-tick", event_roll_range_changed, self,
 			 "swapped-signal::range-changed", event_roll_update, self,
 			 NULL);
       event_roll_range_changed (self);

--- a/beast-gtk/bstpatternview.hh
+++ b/beast-gtk/bstpatternview.hh
@@ -42,7 +42,7 @@ struct _BstPatternView
 {
   GxkScrollCanvas    parent_instance;
 
-  Bse::PartH         part;
+  Bse::PartS         part;
 
   /* vertical layout */
   guint              row_height;

--- a/beast-gtk/bstpianoroll.hh
+++ b/beast-gtk/bstpianoroll.hh
@@ -39,7 +39,7 @@ struct _BstPianoRoll
 {
   GxkScrollCanvas parent_instance;
 
-  Bse::PartH     part;
+  Bse::PartS     part;
   SfiProxy	 song;
   Bse::PartLinkSeq plinks;
   gint		 min_note;

--- a/bse/bseapi.idl
+++ b/bse/bseapi.idl
@@ -769,7 +769,9 @@ interface Part : Item {
   // signal void    range_changed             (int32 a, int32 b, int32 c, int32 d);
   // signal void    links_changed             ();
   // property int32 n_channels;
-  // property int32 last_tick;
+  group "Limits" {
+    int32 last_tick = Range ("Last Tick", "", ":r:G", 0, MAXINT31, 384, 0);
+  };
 };
 
 /// A list of Part or derived types.

--- a/bse/bseapi.idl
+++ b/bse/bseapi.idl
@@ -770,7 +770,8 @@ interface Part : Item {
   // signal void    links_changed             ();
   // property int32 n_channels;
   group "Limits" {
-    int32 last_tick = Range ("Last Tick", "", ":r:G", 0, MAXINT31, 384, 0);
+    int32 last_tick  = Range ("Last Tick", "", ":r:G", 0, MAXINT31, 384, 0);
+    int32 n_channels = Range ("Channels", "", STANDARD, 1, 1024, 4, 1);
   };
 };
 

--- a/bse/bsepart.cc
+++ b/bse/bsepart.cc
@@ -23,7 +23,6 @@ enum
 {
   PROP_0,
   PROP_N_CHANNELS,
-  PROP_LAST_TICK,
 };
 
 
@@ -112,11 +111,6 @@ bse_part_class_init (BsePartClass *klass)
 			      sfi_pspec_int ("n_channels", "Channels", NULL,
 					     1, 1, BSE_PART_MAX_CHANNELS, 4,
 					     SFI_PARAM_STANDARD));
-  bse_object_class_add_param (object_class, "Limits",
-			      PROP_LAST_TICK,
-			      sfi_pspec_int ("last_tick", "Last Tick", NULL,
-					     0, 0, BSE_PART_MAX_TICK, 384,
-					     SFI_PARAM_GUI_READABLE));
 
   signal_range_changed = bse_object_class_add_signal (object_class, "range-changed",
 						      G_TYPE_NONE, 4,
@@ -172,9 +166,6 @@ bse_part_set_property (GObject        *object,
       while (self->n_channels > n)
         bse_part_note_channel_destroy (&self->channels[--self->n_channels]);
       break;
-    case PROP_LAST_TICK:
-      assert_return_unreached ();
-      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (self, param_id, pspec);
       break;
@@ -192,9 +183,6 @@ bse_part_get_property (GObject	  *object,
     {
     case PROP_N_CHANNELS:
       g_value_set_int (value, self->n_channels);
-      break;
-    case PROP_LAST_TICK:
-      g_value_set_int (value, self->last_tick_SL);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (self, param_id, pspec);
@@ -338,7 +326,8 @@ part_update_last_tick (BsePart *self)
   BSE_SEQUENCER_LOCK ();
   self->last_tick_SL = last_tick;
   BSE_SEQUENCER_UNLOCK ();
-  g_object_notify ((GObject*) self, "last-tick");
+  auto impl = self->as<Bse::PartImpl*>();
+  impl->notify ("last_tick");
   bse_part_links_changed (self);
 }
 
@@ -2088,6 +2077,20 @@ PartImpl::PartImpl (BseObject *bobj) :
 
 PartImpl::~PartImpl ()
 {}
+
+int
+PartImpl::last_tick() const
+{
+  BsePart *self = const_cast<PartImpl*> (this)->as<BsePart*>();
+
+  return self->last_tick_SL;
+}
+
+void
+PartImpl::last_tick (int tick)
+{
+  assert_return_unreached ();
+}
 
 PartNoteSeq
 PartImpl::list_notes_crossing (int tick, int duration)

--- a/bse/bsepart.cc
+++ b/bse/bsepart.cc
@@ -18,14 +18,6 @@
 #define peek_or_return          bse_storage_scanner_peek_or_return
 
 
-/* --- properties --- */
-enum
-{
-  PROP_0,
-  PROP_N_CHANNELS,
-};
-
-
 /* --- prototypes --- */
 static void	    bse_part_class_init		(BsePartClass	*klass);
 static void	    bse_part_init		(BsePart	*self);
@@ -106,12 +98,6 @@ bse_part_class_init (BsePartClass *klass)
   quark_insert_control = g_quark_from_static_string ("insert-control");
   quark_insert_controls = g_quark_from_static_string ("insert-controls");
 
-  bse_object_class_add_param (object_class, "Limits",
-			      PROP_N_CHANNELS,
-			      sfi_pspec_int ("n_channels", "Channels", NULL,
-					     1, 1, BSE_PART_MAX_CHANNELS, 4,
-					     SFI_PARAM_STANDARD));
-
   signal_range_changed = bse_object_class_add_signal (object_class, "range-changed",
 						      G_TYPE_NONE, 4,
 						      G_TYPE_INT, G_TYPE_INT,
@@ -146,7 +132,8 @@ part_add_channel (BsePart *self,
   guint i = self->n_channels++;
   self->channels = g_renew (BsePartNoteChannel, self->channels, self->n_channels);
   bse_part_note_channel_init (&self->channels[i]);
-  g_object_notify ((GObject*) self, "n_channels");
+  auto impl = self->as<Bse::PartImpl*>();
+  impl->notify ("n_channels");
 }
 
 static void
@@ -158,14 +145,6 @@ bse_part_set_property (GObject        *object,
   BsePart *self = BSE_PART (object);
   switch (param_id)
     {
-      guint n;
-    case PROP_N_CHANNELS:
-      n = g_value_get_int (value);
-      while (self->n_channels < n)
-        part_add_channel (self, FALSE);
-      while (self->n_channels > n)
-        bse_part_note_channel_destroy (&self->channels[--self->n_channels]);
-      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (self, param_id, pspec);
       break;
@@ -181,9 +160,6 @@ bse_part_get_property (GObject	  *object,
   BsePart *self = BSE_PART (object);
   switch (param_id)
     {
-    case PROP_N_CHANNELS:
-      g_value_set_int (value, self->n_channels);
-      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (self, param_id, pspec);
       break;
@@ -773,7 +749,10 @@ bse_part_insert_note (BsePart *self,
   if (use_any_channel)
     channel = 0;
   else if (channel >= self->n_channels)
-    g_object_set (self, "n_channels", channel + 1, NULL);
+    {
+      auto impl = self->as<Bse::PartImpl*>();
+      impl->n_channels (channel + 1);
+    }
 
   if (!(BSE_NOTE_IS_VALID (note) &&
 	BSE_FINE_TUNE_IS_VALID (fine_tune) &&
@@ -2090,6 +2069,30 @@ void
 PartImpl::last_tick (int tick)
 {
   assert_return_unreached ();
+}
+
+int
+PartImpl::n_channels() const
+{
+  BsePart *self = const_cast<PartImpl*> (this)->as<BsePart*>();
+
+  return self->n_channels;
+}
+
+void
+PartImpl::n_channels (int channels)
+{
+  BsePart *self = as<BsePart*>();
+
+  int value = self->n_channels;
+  if (APPLY_IDL_PROPERTY (value, channels))
+    {
+      uint n = value;
+      while (self->n_channels < n)
+        part_add_channel (self, FALSE);
+      while (self->n_channels > n)
+        bse_part_note_channel_destroy (&self->channels[--self->n_channels]);
+    }
 }
 
 PartNoteSeq

--- a/bse/bsepart.hh
+++ b/bse/bsepart.hh
@@ -269,6 +269,8 @@ protected:
   virtual               ~PartImpl               ();
 public:
   explicit               PartImpl               (BseObject*);
+  virtual int            last_tick              () const override;
+  virtual void           last_tick              (int val) override;
   virtual PartNoteSeq    list_notes_crossing    (int tick, int duration) override;
   virtual PartNoteSeq    list_notes_within      (int channel, int tick, int duration) override;
   virtual PartNoteSeq    list_selected_notes    () override;

--- a/bse/bsepart.hh
+++ b/bse/bsepart.hh
@@ -164,7 +164,6 @@ BsePartEventType   bse_part_query_event         (BsePart           *self,
 
 
 /* --- implementation details --- */
-#define BSE_PART_MAX_CHANNELS           (0x1024)
 #define BSE_PART_MAX_TICK               (0x7fffffff)
 #define BSE_PART_INVAL_TICK_FLAG        (0x80000000)
 #define BSE_PART_NOTE_CONTROL(ctype)    ((ctype) == Bse::MidiSignal::VELOCITY || \
@@ -271,6 +270,8 @@ public:
   explicit               PartImpl               (BseObject*);
   virtual int            last_tick              () const override;
   virtual void           last_tick              (int val) override;
+  virtual int            n_channels             () const override;
+  virtual void           n_channels             (int val) override;
   virtual PartNoteSeq    list_notes_crossing    (int tick, int duration) override;
   virtual PartNoteSeq    list_notes_within      (int channel, int tick, int duration) override;
   virtual PartNoteSeq    list_selected_notes    () override;

--- a/bse/bsetrack.cc
+++ b/bse/bsetrack.cc
@@ -17,6 +17,7 @@
 #include "bsesoundfontrepo.hh"
 #include "bsesoundfontpreset.hh"
 #include "bsesoundfont.hh"
+#include "bsepart.hh"
 #include "bsecxxplugin.hh"
 #include "bse/internal.hh"
 #include <string.h>
@@ -917,7 +918,8 @@ bse_track_get_last_tick (BseTrack *self)
     {
       BseItem *item = BSE_ITEM (self);
       Bse::SongTiming timing;
-      g_object_get (part, "last-tick", &last_tick, NULL);
+      auto partimpl = part->as<Bse::PartImpl*>();
+      last_tick = partimpl->last_tick();
       if (BSE_IS_SONG (item->parent))
         bse_song_get_timing (BSE_SONG (item->parent), offset, &timing);
       else


### PR DESCRIPTION
This is a C++ port of the two Part properties - last_tick and n_channels. I saw there is some signal reemission code in bsetrack.cc, seemingly related to last_tick updates, which looks like this:
```
bse_object_reemit_signal (part, "notify::last-tick", self, "changed");
...
bse_object_remove_reemit (part, "notify::last-tick", self, "changed");
```
I don't know what a port of this would look like.