### PR TITLE
Force alsa default device

### DIFF
--- a/bse/bsedevice.cc
+++ b/bse/bsedevice.cc
@@ -88,6 +88,15 @@ bse_device_open (BseDevice      *self,
   assert_return (BSE_IS_DEVICE (self), Bse::Error::INTERNAL);
   assert_return (!BSE_DEVICE_OPEN (self), Bse::Error::INTERNAL);
   Bse::Error error = Bse::Error::DEVICE_NOT_AVAILABLE;
+  if (!arg_string)
+    {
+      /* if the user didn't specify a device, we use the default device of the
+       * driver (if the driver has a default device) - for ALSA this typically
+       * means we will use "default" as arg_string
+       */
+      if (BSE_DEVICE_GET_CLASS (self)->default_device)
+        arg_string = BSE_DEVICE_GET_CLASS (self)->default_device (self);
+    }
   if (arg_string)
     error = device_open_args (self, need_readable, need_writable, arg_string);
   else

--- a/bse/bsedevice.hh
+++ b/bse/bsedevice.hh
@@ -51,6 +51,7 @@ struct BseDeviceClass : BseObjectClass {
   void                (*post_open)     (BseDevice    *device);
   void                (*pre_close)     (BseDevice    *device);
   void                (*close)         (BseDevice    *device);
+  const char*         (*default_device) (BseDevice   *device);
 };
 struct BseDeviceEntry {
   BseDevice      *device;

--- a/drivers/bsepcmdevice-alsa.cc
+++ b/drivers/bsepcmdevice-alsa.cc
@@ -189,6 +189,25 @@ bse_pcm_device_alsa_list_devices (BseDevice *device)
   return ring;
 }
 
+static const char *
+bse_pcm_device_alsa_default_device (BseDevice *device)
+{
+  /* we check if the "default" device is available */
+  SfiRing *entries = nullptr;
+  entries = list_pcm_devices (device, entries, "Duplex");
+  entries = list_pcm_devices (device, entries, "Output");
+
+  const char *default_device = nullptr;
+  for (SfiRing *node = entries; node; node = sfi_ring_walk (node, entries))
+    {
+      BseDeviceEntry *entry = (BseDeviceEntry*) node->data;
+      if (strcmp (entry->device_args, "default") == 0)
+        default_device = "default";
+    }
+  bse_device_entry_list_free (entries);
+  return default_device;
+}
+
 static void
 silent_error_handler (const char *file,
                       int         line,
@@ -576,6 +595,7 @@ bse_pcm_device_alsa_class_init (BsePcmDeviceALSAClass *klass)
   gobject_class->finalize = bse_pcm_device_alsa_finalize;
 
   device_class->list_devices = bse_pcm_device_alsa_list_devices;
+  device_class->default_device = bse_pcm_device_alsa_default_device;
   const gchar *name = "alsa";
   const gchar *syntax = _("PLUGIN:CARD,DEV,SUBDEV");
   const gchar *info = g_intern_format (/* TRANSLATORS: keep this text to 70 chars in width */


### PR DESCRIPTION
This is a fix for #119 - and finally should make beast work out of the box for users which have pulseaudio as default device (for instance together with jack/bridging). For me at least this fixes "make run".

In order to force using the default device if available, pcm drivers can return a string which device is the default device.