### PR TITLE
BSE: bsemathsignal: add approximations: Bse::fast_log2 and Bse::fast_exp2

### DIFF
--- a/bse/bsemathsignal.hh
+++ b/bse/bsemathsignal.hh
@@ -706,4 +706,275 @@ bse_cent_tune_fast (int fine_tune)
   return bse_cent_table[CLAMP (fine_tune, -100, 100)];
 }
 
+namespace Bse {
+
+/**
+ * @param  value positive input value
+ * @return y     approximating log2 (value)
+ *
+ * Template arguments:
+ *   ORDER  tradeoff between speed and accuracy of the approximation
+ *   T      whether to use double or float for internal calculations
+ *
+ * This function computes a fast approximation for log2. The first template
+ * argument ORDER must be specified. The second selects the floating point
+ * type and defaults to double.
+ *
+ * fast_log2<2> (value)
+ *   is the fastest version with the largest approximation error
+ * fast_log2<9> (value)
+ *   is the slowest version with the smallest approximation error
+ *
+ * In cases where only a float value is required, the second template argument
+ * T can be set to float. Typically this will be a bit faster than using double
+ * precision internally. In that case the ORDER can be at most 6, since for
+ * higher orders the error introduced by float computations is too high.
+ *
+ * Maximum approximation error in interval [1;2] for different values ORDER is
+ * (first value T = double, second value T = float)
+ *
+ *   2  0.00493976    0.004940044
+ *   3  0.0006371173  0.0006375115
+ *   4  8.759192e-05  8.858764e-05
+ *   5  1.253874e-05  1.412891e-05
+ *   6  1.845687e-06  4.548069e-06
+ *   7  2.772895e-07  -
+ *   8  4.231443e-08  -
+ *   9  6.53724e-09   -
+ *
+ * The error is computed as: | log2 (value) - fast_log2 (value) |
+ */
+template<int ORDER, typename T = double>
+static inline T G_GNUC_CONST
+fast_log2 (float value)
+{
+  union {
+    float f;
+    int i;
+  } float_u;
+  float_u.f = value;
+  // compute log_2 using float exponent
+  const int log_2 = ((float_u.i >> 23) & 255) - 128;
+  // replace float exponent
+  float_u.i &= ~(255 << 23);
+  float_u.i += BSE_FLOAT_BIAS << 23;
+
+  static_assert (ORDER >= 2 && ORDER <= 9);
+  if constexpr (std::is_same<float, T>::value)
+    static_assert (ORDER <= 6);
+
+  T x = float_u.f;
+
+  // polynomials designed with: lolremez -d <ORDER> -r 1:2 "log(x)/log(2)+1"
+  if constexpr (ORDER == 2)
+    {
+      T u = -3.4484843300001946e-1;
+      u = u * x + T (2.0246657790474698);
+      x = u * x + T (-6.748775860711561e-1);
+    }
+  else if constexpr (ORDER == 3)
+    {
+      T u = 1.5824870260836496e-1;
+      u = u * x + T (-1.0518750217176431);
+      u = u * x + T (3.0478841468943746);
+      x = u * x + T (-1.1536207104929913);
+    }
+  else if constexpr (ORDER == 4)
+    {
+      T u = -8.1615808498122383e-2;
+      u = u * x + T (6.4514236358772082e-1);
+      u = u * x + T (-2.1206751311142674);
+      u = u * x + T (4.0700907918522014);
+      x = u * x + T (-1.5128546239033371);
+    }
+  else if constexpr (ORDER == 5)
+    {
+      T u = 4.4873610194131727e-2;
+      u = u * x + T (-4.1656368651734915e-1);
+      u = u * x + T (1.6311487636297217);
+      u = u * x + T (-3.5507929249026341);
+      u = u * x + T (5.0917108110420042);
+      x = u * x + T (-1.8003640347009253);
+    }
+  else if constexpr (ORDER == 6)
+    {
+      T u = -2.5691088815846394e-2;
+      u = u * x + T (2.7514877034856807e-1);
+      u = u * x + T (-1.2669182593669425);
+      u = u * x + T (3.2865287704176774);
+      u = u * x + T (-5.3419892025067624);
+      u = u * x + T (6.1129631283200212);
+      x = u * x + T (-2.0400402727100282);
+    }
+  else if constexpr (ORDER == 7)
+    {
+      T u = 1.5125359168008401e-2;
+      u = u * x + T (-1.8393964232233078e-1);
+      u = u * x + T (9.7809484881021081e-1);
+      u = u * x + T (-2.9850211023586282);
+      u = u * x + T (5.7814391203775074);
+      u = u * x + T (-7.494130176731051);
+      u = u * x + T (7.1339697617832616);
+      x = u * x + T (-2.2455378914374758);
+    }
+  else if constexpr (ORDER == 8)
+    {
+      T u = -9.0889081045466651e-3;
+      u = u * x + T (1.2384570293556399e-1);
+      u = u * x + T (-7.4835742226622081e-1);
+      u = u * x + T (2.6387738689074552);
+      u = u * x + T (-6.0134326106109641);
+      u = u * x + T (9.2859836735642522);
+      u = u * x + T (-1.0007135250742891e+1);
+      u = u * x + T (8.1548040722981051);
+      x = u * x + T (-2.4253930836663341);
+    }
+  else if constexpr (ORDER == 9)
+    {
+      T u = 5.547594786690081e-3;
+      u = u * x + T (-8.3767270477714422e-2);
+      u = u * x + T (5.6751026819556446e-1);
+      u = u * x + T (-2.2749487308928086);
+      u = u * x + T (5.9910685362749332);
+      u = u * x + T (-1.0884909361115433e+1);
+      u = u * x + T (1.3970237262129601e+1);
+      u = u * x + T (-1.2880952951531813e+1);
+      u = u * x + T (9.1755128331255977);
+      x = u * x + T (-2.585298173957386);
+    }
+
+   return x + log_2;
+}
+
+/**
+ * @param  ex exponent within [-127..+127]
+ * @return y  approximating 2^ex
+ *
+ * Template arguments:
+ *   ORDER  tradeoff between speed and accuracy of the approximation
+ *   T      whether to use double or float for internal calculations
+ *
+ * This function computes a fast approximation for exp2. The first template
+ * argument ORDER must be specified. The second selects the floating point
+ * type and defaults to double.
+ *
+ * fast_exp2<2> (ex)
+ *   is the fastest version with the largest approximation error
+ * fast_exp2<9> (ex)
+ *   is the slowest version with the smallest approximation error
+ *
+ * In cases where only a float value is required, the second template argument
+ * T can be set to float. Typically this will be a bit faster than using double
+ * precision internally. In that case the ORDER can be at most 6, since for
+ * higher orders the error introduced by float computations is too high.
+ *
+ * Maximum relative approximation error in interval [-1;1] for different
+ * values ORDER is (first value T = double, second value T = float)
+ *
+ *   2  0.001724763   0.001724847
+ *   3  7.478144e-05  7.482798e-05
+ *   4  2.593371e-06  2.70684e-06
+ *   5  7.493647e-08  2.333446e-07
+ *   6  1.8558e-09    9.54076e-08
+ *   7  4.021119e-11  -
+ *   8  7.746751e-13  -
+ *   9  1.375958e-14  -
+ *
+ * The relative error is computed as: | exp2 (x) - fast_exp2 (x) | / exp2 (x)
+ */
+template<int ORDER, typename T = double>
+static inline T G_GNUC_CONST
+fast_exp2 (float ex)
+{
+  BseFloatIEEE754 fp = { 0, };
+  int i = bse_ftoi (ex);
+  fp.mpn.biased_exponent = BSE_FLOAT_BIAS + i;
+  T x = ex - i;
+
+  static_assert (ORDER >= 2 && ORDER <= 9);
+  if constexpr (std::is_same<float, T>::value)
+    static_assert (ORDER <= 6);
+
+  // polynomials designed with: lolremez -d <ORDER> -r -0.5:0.5 "exp(log(2)*x)" "exp(log(2)*x)"
+  if constexpr (ORDER == 2)
+    {
+      T u = 2.3842893576403885e-1;
+      u = u * x + T (7.0344800589128555e-1);
+      x = u * x + T (1.0004431419562679);
+    }
+  else if constexpr (ORDER == 3)
+    {
+      T u = 5.5171669058037948e-2;
+      u = u * x + T (2.4261112219321803e-1);
+      u = u * x + T (6.9326098546062362e-1);
+      x = u * x + T (9.9992807353939516e-1);
+    }
+  else if constexpr (ORDER == 4)
+    {
+      T u = 9.5701019112108269e-3;
+      u = u * x + T (5.5917860319386755e-2);
+      u = u * x + T (2.4024744827862419e-1);
+      u = u * x + T (6.9312181473668853e-1);
+      x = u * x + T (9.9999926144571251e-1);
+    }
+  else if constexpr (ORDER == 5)
+    {
+      T u = 1.3276471992255869e-3;
+      u = u * x + T (9.6755413344448377e-3);
+      u = u * x + T (5.5507132734988059e-2);
+      u = u * x + T (2.402211972384019e-1);
+      u = u * x + T (6.9314696706476011e-1);
+      x = u * x + T (1.0000000716546848);
+    }
+  else if constexpr (ORDER == 6)
+    {
+      T u = 1.5345812002903348e-4;
+      u = u * x + T (1.339993121934089e-3);
+      u = u * x + T (9.6184889571150709e-3);
+      u = u * x + T (5.5503287769647256e-2);
+      u = u * x + T (2.4022646890634088e-1);
+      u = u * x + T (6.9314720573726808e-1);
+      x = u * x + T (1.0000000005541665);
+    }
+  else if constexpr (ORDER == 7)
+    {
+      T u = 1.5201921594573214e-5;
+      u = u * x + T (1.5469291141688497e-4);
+      u = u * x + T (1.3333922563538754e-3);
+      u = u * x + T (9.6180272536684501e-3);
+      u = u * x + T (5.5504103534479798e-2);
+      u = u * x + T (2.4022651198157586e-1);
+      u = u * x + T (6.9314718072844706e-1);
+      x = u * x + T (9.9999999996168193e-1);
+    }
+  else if constexpr (ORDER == 8)
+    {
+      T u = 1.317585811360802e-6;
+      u = u * x + T (1.5309737422244982e-5);
+      u = u * x + T (1.5403851748734642e-4);
+      u = u * x + T (1.3333452062247541e-3);
+      u = u * x + T (9.6181285428623769e-3);
+      u = u * x + T (5.5504109393417119e-2);
+      u = u * x + T (2.402265069888037e-1);
+      u = u * x + T (6.9314718054651416e-1);
+      x = u * x + T (9.9999999999976235e-1);
+    }
+  else if constexpr (ORDER == 9)
+    {
+      T u = 1.0150336705309648e-7;
+      u = u * x + T (1.3259405609345135e-6);
+      u = u * x + T (1.5252984838653427e-5);
+      u = u * x + T (1.540343494807179e-4);
+      u = u * x + T (1.3333557617604443e-3);
+      u = u * x + T (9.6181291920672461e-3);
+      u = u * x + T (5.5504108668685612e-2);
+      u = u * x + T (2.4022650695649653e-1);
+      u = u * x + T (6.9314718055987097e-1);
+      x = u * x + T (1.0000000000000128);
+    }
+  return fp.v_float * x;
+}
+
+}
+
 #endif /* __BSE_SIGNAL_H__ */


### PR DESCRIPTION
First of all, this adds a function that was missing in bsemathsignal: a `fast_log2` implementation. It works by using the float exponent and approximating the rest of the value using a polynomial. I found a tool that gives optimal polynomial coefficients for a given order: https://github.com/samhocevar/lolremez

Since I was at it already, I also looked at our exp2 approximations. Comparing them to what lolremez would produce, what we do is not ideal. So I also added `fast_exp2`. This has consistently better relative errors. So I suggest as next step replacing `bse_approxN_exp2` by `fast_exp2<N>` everywhere, which should be as fast, but more accurate. Please review the API and let me know if this can be the canonical API for porting the old functions to.

Remarks:
* unlike `bse_approxN_exp2`, our new `fast_exp2<N>` no longer guarantees almost zero error if the argument is an integer; however I think we don't really need to preserve this property 
* I like `Bse::fast_log2` better than `Bse::approx_log2` because when reading code "fast" gives me an idea what the function does and why it was used instead of log2


Relative `exp2(x)` approximation errors in interval [-1:1]:

```
rxprec: bse_approx2_exp2: 0.009017387
rxprec: bse_approx3_exp2: 0.0007944462
rxprec: bse_approx4_exp2: 5.568432e-05
rxprec: bse_approx5_exp2: 3.24224e-06
rxprec: bse_approx6_exp2: 1.614916e-07
rxprec: bse_approx7_exp2: 7.028907e-09
rxprec: bse_approx8_exp2: 2.716875e-10
rxprec: bse_approx9_exp2: 9.445048e-12

rxprec: fast_exp2<2, double>: 0.001724763
rxprec: fast_exp2<3, double>: 7.478144e-05
rxprec: fast_exp2<4, double>: 2.593371e-06
rxprec: fast_exp2<5, double>: 7.493647e-08
rxprec: fast_exp2<6, double>: 1.8558e-09
rxprec: fast_exp2<7, double>: 4.021119e-11
rxprec: fast_exp2<8, double>: 7.746751e-13
rxprec: fast_exp2<9, double>: 1.375958e-14
```