### PR TITLE
BSE: driver-alsa.cc: fix crash in retrigger code

### DIFF
--- a/bse/driver-alsa.cc
+++ b/bse/driver-alsa.cc
@@ -427,7 +427,8 @@ public:
     if (write_handle_)
       {
         int n, buffer_length = n_periods_ * period_size_; // buffer size chosen by ALSA based on latency request
-        const float *zeros = bse_engine_const_zeros (buffer_length / 2); // sizeof (int16) / sizeof (float)
+        const size_t frame_size = n_channels_ * sizeof (period_buffer_[0]);
+        const uint8  zeros[buffer_length * frame_size] = { 0, };
         do
           n = snd_pcm_writei (write_handle_, zeros, buffer_length);
         while (n == -EAGAIN); // retry on signals


### PR DESCRIPTION
I was playing a bit with the new alsa driver, and I found that for my first hw device, it crashed like this:

```
stefan@quadcorn:~/src/3rd-tree/ghbeast (master *% u=)$ LANG=C beast
beast: unable to acquire soft realtime priority: Permission denied
beast-0.15.0: bse/bseengineutils.cc:632: bse_engine_const_zeros: assertion failed: smaller_than_BSE_STREAM_MAX_VALUES <= (1024 )
beast-0.15.0: pcm.c:1424: snd_pcm_writei: Assertion `size == 0 || buffer' failed.
```

The problem is that bseengineutils.cc imposes a limit on how big a const zeros float block can be, and on my device, the amount of zero data for the retrigger was larger than 1024 floats, so the driver ended up trying to write a null pointer.

I fixed this crash, and I think I also found another mistake here: n_channels was not taken into account by your original code (buffer_length / 2 would be wrong), so in the fixed version it uses n_channels * sizeof (int16) bytes per frame.