### PR TITLE
BSE: Jack: add midi driver

### DIFF
--- a/bse/driver-jack.cc
+++ b/bse/driver-jack.cc
@@ -697,14 +697,14 @@ public:
         char port_name[port_name_size];
         jack_port_t *port;
 
-        snprintf (port_name, port_name_size, "in_%u", i);
+        snprintf (port_name, port_name_size, "in_%u", i + 1);
         port = jack_port_register (jack_client_, port_name, JACK_DEFAULT_AUDIO_TYPE, JackPortIsInput, 0);
         if (port)
           input_ports_.push_back (port);
         else
           error = Bse::Error::FILE_OPEN_FAILED;
 
-        snprintf (port_name, port_name_size, "out_%u", i);
+        snprintf (port_name, port_name_size, "out_%u", i + 1);
         port = jack_port_register (jack_client_, port_name, JACK_DEFAULT_AUDIO_TYPE, JackPortIsOutput, 0);
         if (port)
           output_ports_.push_back (port);
@@ -984,7 +984,7 @@ public:
   {
     assert_return (midi_input_port_ == nullptr, false);
     midi_driver_callback_ = callback;
-    midi_input_port_ = jack_port_register (jack_client_, "midi-in", JACK_DEFAULT_MIDI_TYPE, JackPortIsInput, 0);
+    midi_input_port_ = jack_port_register (jack_client_, "midi_in", JACK_DEFAULT_MIDI_TYPE, JackPortIsInput, 0);
 
     if (jack_connect (jack_client_, from_port.c_str(), jack_port_name (midi_input_port_)) != 0)
       {

--- a/bse/driver-jack.cc
+++ b/bse/driver-jack.cc
@@ -986,7 +986,8 @@ public:
     midi_driver_callback_ = callback;
     midi_input_port_ = jack_port_register (jack_client_, "midi_in", JACK_DEFAULT_MIDI_TYPE, JackPortIsInput, 0);
 
-    if (jack_connect (jack_client_, from_port.c_str(), jack_port_name (midi_input_port_)) != 0)
+    const bool auto_connect = from_port != "no-auto-connect";
+    if (auto_connect && jack_connect (jack_client_, from_port.c_str(), jack_port_name (midi_input_port_)) != 0)
       {
         jack_port_unregister (jack_client_, midi_input_port_);
         midi_input_port_ = nullptr;

--- a/docs/howto-jack.md
+++ b/docs/howto-jack.md
@@ -83,23 +83,28 @@ used to start JACK with midi support.
         Routing via the JACK Audio Connection Kit
         Note: JACK adds latency compared to direct hardware access
 
+In ebeast, the available jack midi inputs are listed in the preferences dialog.
+
 ### External midi input in BEAST
 
-Normally, the jack midi driver will automatically connect to the first hardware
-device, so starting BEAST and loading "MIDI Test" from the "Demo" menu should
-just work. You should be able to use an external midi keyboard and the events
-should be delivered via jack midi to BEAST.
+If you have external midi devices, the jack midi driver (as auto-detected) will
+automatically connect to the first hardware device (if any), so starting BEAST
+and loading "MIDI Test" from the "Demo" menu should just work. You should be
+able to use an external midi keyboard and the events should be delivered via
+jack midi to BEAST.
 
 In case you have more than one jack midi input, you may need to select the
 correct one using something like
 
     $ beast -m jack=system:midi_capture_1
 
+In ebeast, you can select the jack midi device using the preferences dialog.
+
 ### Manually connecting the midi input
 
-There are cases where the default midi driver strategy "connect to physical device"
-is not sufficient. One case is if you wish to use jack-keyboard. You start it
-using
+There are cases where the default midi driver strategy "connect to physical
+device" is not sufficient. One case is if you wish to use jack-keyboard. You
+start it using
 
     $ jack-keyboard
 
@@ -107,11 +112,13 @@ and then run BEAST as (which will not connect to physical device)
 
     $ beast -m jack=no-auto-connect
 
-and start "MIDI Test" from "Demo" menu. BEAST will not try to connect any midi
-input, and certainly we have no physical input here. But once BEAST is running,
-you can click on the "Connected to:" combobox in the jack-keyboard window. It
-will allow you selecting "Beast:midi_in" and like this you can use the virtual
-keyboard for BEAST.
+and start "MIDI Test" from "Demo" menu. Once BEAST is running, you can click on
+the "Connected to:" combobox in the jack-keyboard window. It will allow you to
+select "Beast:midi_in_1" and like this you can use the virtual keyboard for
+BEAST.
+
+In ebeast, the "no-auto-connect" jack midi device can be selected from the
+preferences dialog.
 
 ### Useful graphical applications
 

--- a/docs/howto-jack.md
+++ b/docs/howto-jack.md
@@ -1,7 +1,9 @@
 JACK Howto Ubuntu 16.04:
 ========================
 
-## First Step: Default Setup (Pulse Audio)
+## JACK & Audio
+
+### First Step: Default Setup (Pulse Audio)
 
 As first step we'll describe the environment we expect, the Ubuntu 16.04
 defaults, which means that your session should be running under PulseAudio.
@@ -13,7 +15,7 @@ sound.  To check that you're really using PulseAudio, start
 
 You should see the audio stream being played via PulseAudio.
 
-## Second Step: Start JACK
+### Second Step: Start JACK
 
 To start Jackd, it is important that the audio device is not used by
 pulseaudio. So we use pasuspender to start JACK like this:
@@ -27,7 +29,7 @@ Jackd should be running now. You need to leave this jackd process running.
 
 If you are not using pulseaudio, use "jackd -r -d alsa" instead.
 
-## Third Step: Start BEAST with Jack Output
+### Third Step: Start BEAST with Jack Output
 
     $ beast -p jack
 
@@ -35,7 +37,7 @@ Open Demo/Party Monster. Press Play. You should hear sound now. As we have
 forced BEAST to use the jack driver, the sound is now definitely going through
 JACK.
 
-## Forth Step: Verify BEAST is using JACK
+### Forth Step: Verify BEAST is using JACK
 
     $ jack_lsp
 
@@ -46,10 +48,74 @@ You should see BEAST ports, like
     beast:in_1
     beast:out_1
 
-## Fifth Step: Show Connections
+### Fifth Step: Show Connections
 
     $ qjackctl
 
 Click on the "Connections" Button. You should see the BEAST ports connected to
 the system input/output. If you have other jack aware applications running, you
 should be able to connect the BEAST input/output from/to other applications.
+
+## JACK & MIDI
+
+### Configure JACK for external midi input
+
+For external midi jackd needs to be started with additional options like
+
+    $ pasuspender -- jackd -r -d alsa -d hw:2 --midi raw
+
+    -r avoids realtime mode which requires special rights
+    -d alsa uses the JACK ALSA backend
+    -d hw:2 select ALSA soundcard
+    --midi raw enable midi input/output
+
+Then, the "Connections" button in qjackctl will show midi input and output
+ports under "Jack MIDI". Of course graphical frontends like qjackctl can be
+used to start JACK with midi support.
+
+### Listing available JACK external Midi Inputs:
+
+    $ beast --bse-driver-list
+    ...
+    jack=system:midi_capture_1:    (Input, 01000000)
+        JACK Midi "system:midi_capture_1" [Physical: in-hw-2-0-0-UA-25EX-MIDI-1]
+        Hardware Midi Input
+        Routing via the JACK Audio Connection Kit
+        Note: JACK adds latency compared to direct hardware access
+
+### External midi input in BEAST
+
+Normally, the jack midi driver will automatically connect to the first hardware
+device, so starting BEAST and loading "MIDI Test" from the "Demo" menu should
+just work. You should be able to use an external midi keyboard and the events
+should be delivered via jack midi to BEAST.
+
+In case you have more than one jack midi input, you may need to select the
+correct one using something like
+
+    $ beast -m jack=system:midi_capture_1
+
+### Manually connecting the midi input
+
+There are cases where the default midi driver strategy "connect to physical device"
+is not sufficient. One case is if you wish to use jack-keyboard. You start it
+using
+
+    $ jack-keyboard
+
+and then run BEAST as (which will not connect to physical device)
+
+    $ beast -m jack=no-auto-connect
+
+and start "MIDI Test" from "Demo" menu. BEAST will not try to connect any midi
+input, and certainly we have no physical input here. But once BEAST is running,
+you can click on the "Connected to:" combobox in the jack-keyboard window. It
+will allow you selecting "Beast:midi_in" and like this you can use the virtual
+keyboard for BEAST.
+
+### Useful graphical applications
+
+A recommendation for visualizing jack connections is "Carla", which shows which
+ports are connected to which ports and which clients exist. Another good tool
+is "Qjackctl", which can start jackd without requiring knowledge which options
+are available. It can also connect clients.


### PR DESCRIPTION
So here is a midi (input) driver for jack. The audio/midi driver share the same jack client, I documented the assumptions I have to make for the communication of the two in the code. While the audio driver typically only has one option (the default audio device), for midi there can be more than one choice. For example here is the relevant part of `--bse-driver-list` on my system if I configure jackd to do the midi handling - we get one possible device in this case:
```
Available MIDI drivers:
  jack=system:midi_capture_1:    (Input, 01000000)
        JACK Midi "system:midi_capture_1" [Physical: in-hw-2-0-0-UA-25EX-MIDI-1]
        Hardware Midi Input
        Routing via the JACK Audio Connection Kit
        Note: JACK adds latency compared to direct hardware access
```
And the same system using alsa midi bridge setting in cadence (uses a2jmidid):
```
Available MIDI drivers:
  jack=a2j:Midi Through [14] (capture): Midi Through Port-0: (Input, 01000000)
        JACK Midi "a2j:Midi Through [14] (capture): Midi Through Port-0"
        Hardware Midi Input
        Routing via the JACK Audio Connection Kit
        Note: JACK adds latency compared to direct hardware access
  jack=a2j:UA-25EX [24] (capture): UA-25EX MIDI 1: (Input, 01000001)
        JACK Midi "a2j:UA-25EX [24] (capture): UA-25EX MIDI 1"
        Hardware Midi Input
        Routing via the JACK Audio Connection Kit
        Note: JACK adds latency compared to direct hardware access
```
So here we get more than one device entry, and if there were more midi devices we would get even more. In this case we have relatively long device names, but we need both: client name and port name to distinguish between devices.

I also added a comment about auto connect which should really be configurable one day; still even without that the midi driver should be usable.