### PR TITLE
TESTS: make time consuming resampler tests run as slow tests

### DIFF
--- a/tests/resamplehandle.cc
+++ b/tests/resamplehandle.cc
@@ -117,7 +117,7 @@ check (const char           *up_down,
   TCHECK (worst_diff_db < max_db, "%s: seeking below epsilon: %.1f < %.1f dB", samplestr, worst_diff_db, max_db);
 
   // benchmarks
-  if (1)
+  if (Bse::Test::slow())
     {
       const uint RUNS = 1;
       const uint bytes_per_run = sizeof (float) * gsl_data_handle_n_values (rhandle);
@@ -426,7 +426,7 @@ test_resample_delay_compensation()
   if (Resampler2::sse_available())
     test_delay_compensation (true);
 }
-TEST_ADD (test_resample_delay_compensation);
+TEST_SLOW (test_resample_delay_compensation);
 
 static void
 test_resample_state_length()
@@ -447,25 +447,25 @@ test_resample_handle_12()
 {
   run_tests ("SSE", 1);
 }
-TEST_ADD (test_resample_handle_12);
+TEST_SLOW (test_resample_handle_12);
 
 static void
 test_resample_handle_16()
 {
   run_tests ("SSE", 2);
 }
-TEST_ADD (test_resample_handle_16);
+TEST_SLOW (test_resample_handle_16);
 
 static void
 test_resample_handle_20()
 {
   run_tests ("SSE", 3);
 }
-TEST_ADD (test_resample_handle_20);
+TEST_SLOW (test_resample_handle_20);
 
 static void
 test_resample_handle_24()
 {
   run_tests ("SSE", 4);
 }
-TEST_ADD (test_resample_handle_24);
+TEST_SLOW (test_resample_handle_24);

--- a/tests/testresamplerq.cc
+++ b/tests/testresamplerq.cc
@@ -245,4 +245,4 @@ test_resampler_variants()
   if (Resampler2::sse_available())
     run_tests (true);
 }
-TEST_ADD (test_resampler_variants);
+TEST_SLOW (test_resampler_variants);


### PR DESCRIPTION
I made every resampler test that is somewhat slow run as slow test. This reduces the time it takes to execute all resampler tests on my machine from 1.9 seconds to 0.3 seconds if only one cpu is used. Note that although I added

```
  if (Bse::Test::slow())
```

to execute the resamplehandle benchmarks if and only if we're running as slow tests, I found that the resamplehandle benchmarks are now never executed (which probably doesn't matter). I tried to investigate, `Bse::Test::slow()` does something like
```
  static bool cached_slow = feature_toggle_bool (getenv ("BSE_TEST"), "slow");
```
but that variable is never set elsewhere in the code (or at least I don't find where it is).