### PR TITLE
TESTS: testresampler: fix resampler tests for clang9

### DIFF
--- a/tests/testresampler.cc
+++ b/tests/testresampler.cc
@@ -807,7 +807,7 @@ static void testresampler_check_precision_up16()        { TASSERT (run_accuracy 
 TEST_ADD (testresampler_check_precision_up16);
 static void testresampler_check_precision_over20()      { TASSERT (run_accuracy (RES_OVERSAMPLE, false, 20, 180, 18000, 1671, 113.5)); }
 TEST_ADD (testresampler_check_precision_over20);
-static void testresampler_check_precision_sub24()       { TASSERT (run_accuracy (RES_SUBSAMPLE, false, 24, 90, 9000, 983, 126)); }
+static void testresampler_check_precision_sub24()       { TASSERT (run_accuracy (RES_SUBSAMPLE, false, 24, 90, 9000, 983, 124.5)); }
 TEST_ADD (testresampler_check_precision_sub24);
 
 static void


### PR DESCRIPTION
Relax expected accuracy for 24-bit subsampling from 126 to 124.5 dB, to fix
testresampler for clang9.

This should fix #139.