### PR TITLE
Blepsynth improvements

### DIFF
--- a/devices/blepsynth/TODO
+++ b/devices/blepsynth/TODO
@@ -1,0 +1,9 @@
+QUALITY:
+- seek: slope approximation could improve initial conditions
+
+PERF:
+- specializations for input channels which are not connected
+- speed up dc computation
+- sync specialization
+- possible table-of-exp2
+- some parameters (like sync_factor) can be computed once for all unison voices

--- a/devices/blepsynth/blepsynth.cc
+++ b/devices/blepsynth/blepsynth.cc
@@ -473,6 +473,7 @@ class BlepSynth : public AudioSignal::Processor {
           {
             voice->state_ = Voice::RELEASE;
             voice->envelope_.stop();
+            voice->fil_envelope_.stop();
           }
       }
   }

--- a/devices/blepsynth/blepsynth.cc
+++ b/devices/blepsynth/blepsynth.cc
@@ -263,8 +263,8 @@ class BlepSynth : public AudioSignal::Processor {
       osc_params[o].sub_width = add_param (string_format ("Osc %d Subharmonic Width", o + 1), "Sub.W", 0, 100, 50, "%");
       osc_params[o].sync = add_param (string_format ("Osc %d Sync Slave", o + 1), "Sync", 0, 60, 0, "semitones");
 
-      /* TODO: unison_voices property should be an integer property, range 1-16, default 1 */
-      osc_params[o].unison_voices = add_param (string_format ("Osc %d Unison Voices", o + 1), "Voices", 0, 100, 0, "%");
+      /* TODO: unison_voices property should have stepping set to 1 */
+      osc_params[o].unison_voices = add_param (string_format ("Osc %d Unison Voices", o + 1), "Voices", 1, 16, 1, "voices");
       osc_params[o].unison_detune = add_param (string_format ("Osc %d Unison Detune", o + 1), "Detune", 0.5, 50, 6, "%");
       osc_params[o].unison_stereo = add_param (string_format ("Osc %d Unison Stereo", o + 1), "Stereo", 0, 100, 0, "%");
     };
@@ -380,7 +380,7 @@ class BlepSynth : public AudioSignal::Processor {
     osc.sub_width_base      = get_param (params.sub_width) * 0.01;
     osc.sync_base           = get_param (params.sync);
 
-    int unison_voices = bse_ftoi (get_param (params.unison_voices) * 0.01 * 15 + 1);
+    int unison_voices = bse_ftoi (get_param (params.unison_voices));
     unison_voices = CLAMP (unison_voices, 1, 16);
     osc.set_unison (unison_voices, get_param (params.unison_detune), get_param (params.unison_stereo) * 0.01);
   }
@@ -543,6 +543,15 @@ class BlepSynth : public AudioSignal::Processor {
       }
     if (need_free)
       free_unused_voices();
+  }
+  std::string
+  param_value_to_text (Id32 paramid, double value) const
+  {
+    /* fake step=1 */
+    if (paramid == osc_params[0].unison_voices || paramid == osc_params[1].unison_voices)
+      return string_format ("%d voices", bse_ftoi (value));
+
+    return Processor::param_value_to_text (paramid, value);
   }
   double
   value_to_normalized (Id32 paramid, double value) const override

--- a/devices/blepsynth/blepsynth.cc
+++ b/devices/blepsynth/blepsynth.cc
@@ -220,6 +220,7 @@ class BlepSynth : public AudioSignal::Processor {
   Logscale cutoff_logscale_;
   ParamId pid_resonance_;
   ParamId pid_drive_;
+  ParamId pid_key_track_;
   ParamId pid_mode_;
 
   ParamId pid_attack_;
@@ -253,6 +254,7 @@ class BlepSynth : public AudioSignal::Processor {
 
     LinearSmooth cutoff_smooth_;
     double       last_cutoff_;
+    double       last_key_track_;
 
     LinearSmooth cut_mod_smooth_;
     double       last_cut_mod_;
@@ -297,7 +299,7 @@ class BlepSynth : public AudioSignal::Processor {
     oscparams (0);
 
     start_param_group ("Filter");
-    /* TODO: cutoff property should have logarithmic scaling */
+
     const double FsharpHz = 440 * ::pow (2, 9 / 12.);
     const double freq_lo = FsharpHz / ::pow (2, 5);
     const double freq_hi = FsharpHz * ::pow (2, 5);
@@ -305,6 +307,7 @@ class BlepSynth : public AudioSignal::Processor {
     cutoff_logscale_.setup (freq_lo, freq_hi);
     pid_resonance_ = add_param ("Resonance", "Reso", 0, 100, 25.0, "%");
     pid_drive_ = add_param ("Drive", "Drive", -24, 36, 0, "dB");
+    pid_key_track_ = add_param ("Key Tracking", "KeyTr", 0, 100, 50, "%");
     ChoiceEntries centries;
     centries += { "None", "disable filter" };
     centries += { "L1", "1 pole lowpass, 6db/octave" };
@@ -462,6 +465,7 @@ class BlepSynth : public AudioSignal::Processor {
 
         voice->cut_mod_smooth_.reset (sample_rate(), 0.020);
         voice->last_cut_mod_ = -5000; // force reset
+        voice->last_key_track_ = -5000;
       }
   }
   void
@@ -550,13 +554,18 @@ class BlepSynth : public AudioSignal::Processor {
         float       *outputs[2] = { mix_left_out, mix_right_out };
         double cutoff = get_param (pid_cutoff_) * inyquist();
         double resonance = get_param (pid_resonance_) * 0.01;
+        double key_track = get_param (pid_key_track_) * 0.01;
 
-        if (fabs (voice->last_cutoff_ - cutoff) > 1e-7)
+        if (fabs (voice->last_cutoff_ - cutoff) > 1e-7 || fabs (voice->last_key_track_ - key_track) > 1e-7)
           {
             const bool reset = voice->last_cutoff_ < -1000;
 
-            voice->cutoff_smooth_.set (fast_log2 (cutoff), reset);
+            // original strategy for key tracking: cutoff * exp (amount * log (key / 261.63))
+            // but since cutoff_smooth_ is already in log2-frequency space, we can do it better
+
+            voice->cutoff_smooth_.set (fast_log2 (cutoff) + key_track * fast_log2 (voice->freq_ / 261.63), reset);
             voice->last_cutoff_ = cutoff;
+            voice->last_key_track_ = key_track;
           }
         double cut_mod = get_param (pid_fil_cut_mod_) / 12.; /* convert semitones to octaves */
         if (fabs (voice->last_cut_mod_ - cut_mod) > 1e-7)

--- a/devices/blepsynth/blepsynth.cc
+++ b/devices/blepsynth/blepsynth.cc
@@ -189,8 +189,6 @@ public:
 // - aliasing-free square/saw and similar sounds including hard sync
 class BlepSynth : public AudioSignal::Processor {
   OBusId stereout_;
-  ParamId pid_c_, pid_d_, pid_e_, pid_f_, pid_g_;
-  bool    old_c_, old_d_, old_e_, old_f_, old_g_;
 
   struct OscParams {
     ParamId shape;
@@ -295,14 +293,6 @@ class BlepSynth : public AudioSignal::Processor {
 
     start_param_group ("Mix");
     pid_mix_ = add_param ("Mix", "Mix", 0, 100, 0, "%");
-
-    start_param_group ("Keyboard Input");
-    pid_c_ = add_param ("Main Input  1",  "C", false);
-    pid_d_ = add_param ("Main Input  2",  "D", false);
-    pid_e_ = add_param ("Main Input  3",  "E", false);
-    pid_f_ = add_param ("Main Input  4",  "F", false);
-    pid_g_ = add_param ("Main Input  5",  "G", false);
-    old_c_ = old_d_ = old_e_ = old_f_ = old_g_ = false;
   }
   void
   set_max_voices (uint n_voices)
@@ -447,13 +437,6 @@ class BlepSynth : public AudioSignal::Processor {
   void
   render (uint n_frames) override
   {
-    /* TODO: replace this with true midi input */
-    check_note (pid_c_, old_c_, 60);
-    check_note (pid_d_, old_d_, 62);
-    check_note (pid_e_, old_e_, 64);
-    check_note (pid_f_, old_f_, 65);
-    check_note (pid_g_, old_g_, 67);
-
     EventRange erange = get_event_input();
     for (const auto &ev : erange)
       switch (ev.message())

--- a/devices/blepsynth/blepsynth.cc
+++ b/devices/blepsynth/blepsynth.cc
@@ -197,6 +197,8 @@ class BlepSynth : public AudioSignal::Processor {
     ParamId sub;
     ParamId sub_width;
     ParamId sync;
+    ParamId octave;
+    ParamId pitch;
 
     ParamId unison_voices;
     ParamId unison_detune;
@@ -262,6 +264,9 @@ class BlepSynth : public AudioSignal::Processor {
       osc_params[o].sub = add_param (string_format ("Osc %d Subharmonic", o + 1), "Sub", 0, 100, 0, "%");
       osc_params[o].sub_width = add_param (string_format ("Osc %d Subharmonic Width", o + 1), "Sub.W", 0, 100, 50, "%");
       osc_params[o].sync = add_param (string_format ("Osc %d Sync Slave", o + 1), "Sync", 0, 60, 0, "semitones");
+
+      osc_params[o].pitch  = add_param (string_format ("Osc %d Pitch", o + 1), "Pitch", -7, 7, 0, "semitones");
+      osc_params[o].octave = add_param (string_format ("Osc %d Octave", o + 1), "Octave", -2, 3, 0, "octaves");
 
       /* TODO: unison_voices property should have stepping set to 1 */
       osc_params[o].unison_voices = add_param (string_format ("Osc %d Unison Voices", o + 1), "Voices", 1, 16, 1, "voices");
@@ -367,7 +372,6 @@ class BlepSynth : public AudioSignal::Processor {
     osc.frequency_base = freq;
     osc.set_rate (sample_rate());
 #if 0
-    osc.frequency_factor  = bse_transpose_factor (properties->current_musical_tuning, properties->transpose) * bse_cent_tune_fast (properties->fine_tune);
     osc.freq_mod_octaves  = properties->freq_mod_octaves;
 #endif
   }
@@ -379,6 +383,10 @@ class BlepSynth : public AudioSignal::Processor {
     osc.sub_base            = get_param (params.sub) * 0.01;
     osc.sub_width_base      = get_param (params.sub_width) * 0.01;
     osc.sync_base           = get_param (params.sync);
+
+    int octave = bse_ftoi (get_param (params.octave));
+    octave = CLAMP (octave, -2, 3);
+    osc.frequency_factor = fast_exp2 (octave + get_param (params.pitch) / 12.);
 
     int unison_voices = bse_ftoi (get_param (params.unison_voices));
     unison_voices = CLAMP (unison_voices, 1, 16);
@@ -548,8 +556,13 @@ class BlepSynth : public AudioSignal::Processor {
   param_value_to_text (Id32 paramid, double value) const
   {
     /* fake step=1 */
-    if (paramid == osc_params[0].unison_voices || paramid == osc_params[1].unison_voices)
-      return string_format ("%d voices", bse_ftoi (value));
+    for (int o = 0; o < 2; o++)
+      {
+        if (paramid == osc_params[o].unison_voices)
+          return string_format ("%d voices", bse_ftoi (value));
+        if (paramid == osc_params[o].octave)
+          return string_format ("%d octaves", bse_ftoi (value));
+      }
 
     return Processor::param_value_to_text (paramid, value);
   }

--- a/devices/blepsynth/blepsynth.cc
+++ b/devices/blepsynth/blepsynth.cc
@@ -17,6 +17,9 @@ namespace {
 
 class Envelope
 {
+public:
+  enum class Shape { EXPONENTIAL, LINEAR };
+private:
   /* values in seconds */
   float delay_ = 0;
   float attack_ = 0;
@@ -35,6 +38,7 @@ class Envelope
   enum class State { DELAY, ATTACK, HOLD, DECAY, SUSTAIN, RELEASE, DONE };
 
   State state_ = State::DONE;
+  Shape shape_ = Shape::EXPONENTIAL;
 
   struct SlopeParams {
     int len;
@@ -47,6 +51,11 @@ class Envelope
   double level_ = 0;
 
 public:
+  void
+  set_shape (Shape shape)
+  {
+    shape_ = shape;
+  }
   void
   set_delay (float f)
   {
@@ -108,7 +117,7 @@ public:
   {
     params_.end = end_x;
 
-    if (param_state == State::ATTACK || param_state == State::DELAY || param_state == State::HOLD)
+    if (param_state == State::ATTACK || param_state == State::DELAY || param_state == State::HOLD || shape_ == Shape::LINEAR)
       {
         // linear
         params_.len    = len;

--- a/devices/blepsynth/blepsynth.cc
+++ b/devices/blepsynth/blepsynth.cc
@@ -253,6 +253,10 @@ class BlepSynth : public AudioSignal::Processor {
 
     LinearSmooth cutoff_smooth_;
     double       last_cutoff_;
+
+    LinearSmooth cut_mod_smooth_;
+    double       last_cut_mod_;
+
     BlepUtils::OscImpl osc1_;
     BlepUtils::OscImpl osc2_;
     LadderVCFNonLinear vcf_;
@@ -322,7 +326,7 @@ class BlepSynth : public AudioSignal::Processor {
     pid_fil_decay_    = add_param ("Decay",   "D", 0, 8000, 1500.0, "ms", STANDARD + "logcenter=1000");
     pid_fil_sustain_  = add_param ("Sustain", "S", 0, 100,  30.0, "%");
     pid_fil_release_  = add_param ("Release", "R", 0, 8000, 300.0, "ms", STANDARD + "logcenter=1000");
-    pid_fil_cut_mod_  = add_param ("Env Cutoff Modulation", "CutMod", -96, 96, 60, "semitones"); /* 8 octaves range */
+    pid_fil_cut_mod_  = add_param ("Env Cutoff Modulation", "CutMod", -96, 96, 36, "semitones"); /* 8 octaves range */
 
     start_param_group ("Mix");
     pid_mix_ = add_param ("Mix", "Mix", 0, 100, 0, "%");
@@ -454,7 +458,10 @@ class BlepSynth : public AudioSignal::Processor {
         voice->vcf_.reset();
 
         voice->cutoff_smooth_.reset (sample_rate(), 0.020);
-        voice->last_cutoff_ = -1;
+        voice->last_cutoff_ = -5000; // force reset
+
+        voice->cut_mod_smooth_.reset (sample_rate(), 0.020);
+        voice->last_cut_mod_ = -5000; // force reset
       }
   }
   void
@@ -545,19 +552,26 @@ class BlepSynth : public AudioSignal::Processor {
 
         if (fabs (voice->last_cutoff_ - cutoff) > 1e-7)
           {
-            const bool reset = voice->last_cutoff_ < 0;
+            const bool reset = voice->last_cutoff_ < -1000;
 
-            voice->cutoff_smooth_.set (log2f (cutoff), reset);
+            voice->cutoff_smooth_.set (fast_log2 (cutoff), reset);
             voice->last_cutoff_ = cutoff;
+          }
+        double cut_mod = get_param (pid_fil_cut_mod_) / 12.; /* convert semitones to octaves */
+        if (fabs (voice->last_cut_mod_ - cut_mod) > 1e-7)
+          {
+            const bool reset = voice->last_cut_mod_ < -1000;
+
+            voice->cut_mod_smooth_.set (cut_mod, reset);
+            voice->last_cut_mod_ = cut_mod;
           }
         /* TODO: possible improvements:
          *  - exponential smoothing (get rid of exp2f)
          *  - don't do anything if cutoff_smooth_->steps_ == 0 (add accessor)
          */
-        float cut_mod = get_param (pid_fil_cut_mod_) / 12.; /* convert semitones to octaves */
         float freq_in[n_frames];
         for (uint i = 0; i < n_frames; i++)
-          freq_in[i] = exp2f (voice->cutoff_smooth_.get_next() + voice->fil_envelope_.get_next() * cut_mod);
+          freq_in[i] = fast_exp2 (voice->cutoff_smooth_.get_next() + voice->fil_envelope_.get_next() * voice->cut_mod_smooth_.get_next());
         voice->vcf_.set_drive (get_param (pid_drive_));
 
         float no_out[n_frames];

--- a/devices/blepsynth/blepsynth.cc
+++ b/devices/blepsynth/blepsynth.cc
@@ -429,20 +429,6 @@ class BlepSynth : public AudioSignal::Processor {
       }
   }
   void
-  check_note (ParamId pid, bool& old_value, int note)
-  {
-    const bool value = get_param (pid) > 0.5;
-    if (value != old_value)
-      {
-        constexpr int channel = 0;
-        if (value)
-          note_on (channel, note, 100);
-        else
-          note_off (channel, note);
-        old_value = value;
-      }
-  }
-  void
   render (uint n_frames) override
   {
     EventRange erange = get_event_input();

--- a/devices/blepsynth/bleputils.hh
+++ b/devices/blepsynth/bleputils.hh
@@ -1,0 +1,47 @@
+// Licensed GNU LGPL v2.1 or later: http://www.gnu.org/licenses/lgpl.html
+
+#ifndef __BSE_BLEPUTILS_HH__
+#define __BSE_BLEPUTILS_HH__
+
+#include <assert.h>
+
+namespace Bse {
+namespace BlepUtils {
+
+inline double
+bessel_i0 (double x)
+{
+  /* http://www.vibrationdata.com/Bessel.htm */
+
+  /* 1 + (x/2)^2/(1!^2)
+   *   + (x/2)^4/(2!^2)
+   *   + (x/2)^6/(3!^2)   ... */
+
+  double delta = 1;
+  double result = 1;
+  const double sqr_x_2 = (x/2)*(x/2);
+
+  for (int i = 1; i < 500; i++)
+    {
+      delta *= sqr_x_2 / (i * i);
+      result += delta;
+
+      if (delta < 1e-14 * result)
+        break;
+    }
+  return result;
+}
+
+inline double
+window_kaiser (double x, double beta)
+{
+  // https://en.wikipedia.org/wiki/Kaiser_window
+  const double pos = std::max (1.0 - x * x, 0.0); // avoid problems for |x| > 1
+
+  return bessel_i0 (M_PI * beta * sqrt (pos)) / bessel_i0 (M_PI * beta);
+}
+
+}
+}
+
+#endif

--- a/devices/blepsynth/designblep.cpp
+++ b/devices/blepsynth/designblep.cpp
@@ -1,0 +1,365 @@
+// Licensed GNU LGPL v2.1 or later: http://www.gnu.org/licenses/lgpl.html
+
+#include <stdio.h>
+#include <math.h>
+#include <assert.h>
+#include <bse/bsemathsignal.hh>
+#include <bse/gslfft.hh>
+#include <complex>
+#include <algorithm>
+
+#include "bleputils.hh"
+
+using namespace Bse::BlepUtils;
+
+using std::complex;
+using std::vector;
+using std::string;
+using std::max;
+
+static double
+sinc (double x)
+{
+  return fabs (x) > 1e-8 ? sin (x * M_PI) / (x * M_PI) : 1;
+}
+
+static double *
+complex_ptr (vector<complex<double>>& vec)
+{
+  return reinterpret_cast<double *> (&vec[0]);
+}
+
+static void
+print_fir_response (const vector<double>& fir,
+                    const string& label)
+{
+  size_t N = 1024;
+  while (fir.size() * 8 >= N)
+    N *= 2;
+
+  vector<complex<double>> in_ri (N), out_ri (N);
+
+  for (size_t i = 0; i < N; i++)
+    if (i < fir.size())
+      in_ri[i] = fir[i];
+
+  gsl_power2_fftac (N, complex_ptr (in_ri), complex_ptr (out_ri));
+  for (size_t i = 0; i <= N / 2; i++)
+    {
+      double d = i / double (N) * 2;
+      printf ("%.17g %.17g #%s\n", d, std::abs (out_ri[i]), label.c_str());
+    }
+}
+
+static vector<double>
+mk_fir (int width, int oversample, double low_pass, double beta)
+{
+  const int N = width * oversample;
+  vector<double> fir_filter (2 * N - 1);
+
+  const double stretch = oversample / low_pass * 24000.; /* relative to 48kHz */
+  for (size_t i = 0; i < fir_filter.size(); i++)
+    {
+      double x = i - (N - 1.0);
+      fir_filter[i] = sinc (x / stretch) * window_kaiser (x / (N - 1.0), beta) / stretch;
+    }
+  return fir_filter;
+}
+
+static vector<double>
+load_fir (const char *fname)
+{
+  vector<double> fir_filter;
+
+  FILE *f = fopen (fname, "r");
+  char str[1024];
+  while (fgets (str, 1024, f))
+    {
+      char *p = str;
+      while (*p == ' ' || *p == '\t') // skip leading whitespace
+        p++;
+
+      if (*p != '#' && *p != '\n') // could be a number?
+        fir_filter.push_back (atof (p));
+    }
+  fclose (f);
+
+  return fir_filter;
+}
+
+static int
+next_power_of_two (int N)
+{
+  int P = 2;
+  while (P < N)
+    P *= 2;
+  return P;
+}
+
+static vector<double>
+repeat_n (size_t n, const vector<double>& fir)
+{
+  vector<double> rep_fir;
+
+  for (auto d : fir)
+    for (size_t i = 0; i < n; i++)
+      rep_fir.push_back (d / n);
+
+  return rep_fir;
+}
+
+static vector<double>
+interp_linear (size_t n, const vector<double>& fir)
+{
+  vector<double> interp_fir;
+
+  for (size_t fpos = 0; fpos < fir.size(); fpos++)
+    {
+      double left = fir[fpos];
+      double right = fpos + 1 < fir.size() ? fir[fpos + 1] : 0;
+      for (size_t i = 0; i < n; i++)
+        {
+          double frac = double (i) / n;
+          interp_fir.push_back ((left * (1 - frac) + right * frac) / n);
+        }
+    }
+  return interp_fir;
+}
+
+int
+main (int argc, char **argv)
+{
+  bool trace = false, impulse = false;
+  for (int i = 0; i < argc; i++)
+    {
+      if (strcmp (argv[i], "trace") == 0)
+        trace = true;
+      if (strcmp (argv[i], "impulse") == 0)
+        impulse = true;
+    }
+
+  if (impulse)
+    {
+      const int width = 12;
+      const int oversample = 64;
+
+      vector<double> fir_filter = mk_fir (width / 2, oversample, /* lp */ 24000., /* beta */ 2);
+      fir_filter.push_back (0); /* make filter length even */
+      assert (fir_filter.size() == width * oversample);
+
+      /* obtain total weight */
+      double weight = 0;
+      for (auto f : fir_filter)
+        weight += f;
+
+      /* normalize total weight */
+      for (auto& f : fir_filter)
+        f /= weight;
+
+      /* build step function */
+      double last_value = 0;
+      vector<double> step;
+      for (auto f : fir_filter)
+        {
+          double value = f + last_value;
+          step.push_back (value);
+          last_value = value;
+        }
+      /* always generate diffs which finally reach one */
+      step.insert (step.end(), oversample, 1.0);
+
+      vector<double> delta_step (step.size());
+      for (int frac = 0; frac < oversample; frac++)
+        for (size_t p = frac; p < step.size(); p += oversample)
+          {
+            double old = 0;
+            if (p >= oversample)
+              old = step[p - oversample];
+            delta_step[p] = step[p] - old;
+          }
+      if (trace)
+        {
+          print_fir_response (fir_filter, "Hfir");
+
+          print_fir_response (repeat_n (16, fir_filter), "Hrep");
+          print_fir_response (interp_linear (16, fir_filter), "Hlin");
+
+          for (auto f : fir_filter)
+            printf ("%.17g #impulse\n", f);
+
+          for (int frac = 0; frac < oversample; frac++)
+            {
+              /* debug slice sums */
+              double slice_avg = 0;
+              for (size_t p = frac; p < delta_step.size(); p += oversample)
+                {
+                  slice_avg += delta_step[p];
+                }
+              printf ("%d %.17g #slice\n", frac, slice_avg);
+            }
+
+          for (auto f : step)
+            printf ("%.17g #step\n", f);
+
+          for (auto f : delta_step)
+            printf ("%f #delta_step\n", f);
+        }
+      else
+        {
+          printf ("// this file was generated by designblep\n");
+          printf ("#include \"bleposc.hh\"\n");
+          printf ("const float Bse::BlepUtils::OscImpl::blep_table[%zd] = {\n", delta_step.size() + 1);
+
+          for (auto f : delta_step)
+            printf ("  %.17g,\n", f);
+
+          printf ("  0\n");  /* allow linear interpolation */
+          printf ("};\n");
+        }
+      return 0;
+    }
+
+  vector<double> fir_filter;
+
+  if (1)
+    {
+      /* design low pass FIR filter */
+      fir_filter = mk_fir (/* width */ 16, /* oversample */ 64, /* lp */ 20000., /* beta */ 5);
+    }
+  else
+    {
+      /* load low pass FIR filter */
+      fir_filter = load_fir ("rdemo2fir");
+    }
+  assert ((fir_filter.size() & 1) == 1); // odd length
+  const int N = (fir_filter.size() + 1) / 2;
+
+  if (trace)
+    {
+      for (size_t i = 0; i < fir_filter.size(); i++)
+        printf ("%.17g #Fin\n", fir_filter[i]);
+
+      print_fir_response (fir_filter, "Hin");
+    }
+
+  const size_t M = next_power_of_two (N * 128);
+  vector<complex<double>> theta_ri (M);
+  vector<complex<double>> mag_ri (M);
+  vector<complex<double>> fir_ri (M);
+
+  /* build zero padded impulse response */
+
+  for (size_t i = 0; i < fir_filter.size(); i++)
+    fir_ri[i] = fir_filter[i];
+
+  gsl_power2_fftac (M, complex_ptr (fir_ri), complex_ptr (mag_ri));   /* get spectrum */
+  for (size_t i = 0; i < M; i++)
+    {
+      mag_ri[i] = std::complex<double> (mag_ri[i].real(), -mag_ri[i].imag()); // FIXME: should be done by fft wrapper
+
+      auto a = mag_ri[i] * std::complex<double> (cos (double (i) * (N - 1) * 2 * PI / M), -sin (double (i) * (N - 1) * 2 * PI / M));
+      mag_ri[i] = a.real();
+    }
+
+  double offset = 0.0;
+  for (size_t i = 0; i < M; i++)
+    offset = max (-mag_ri[i].real(), offset);
+
+  /* sqrt for magnitudes */
+  for (size_t i = 0; i < M; i++)
+    mag_ri[i] = sqrt (mag_ri[i].real() + offset) + 1e-10;
+
+  /* compute log|X(n)| */
+  for (size_t i = 0; i < M; i++)
+    {
+      theta_ri[i] = log (mag_ri[i].real());
+    }
+
+  vector<complex<double>> theta_ri_ifft (M);
+  gsl_power2_fftsc (M, complex_ptr (theta_ri), complex_ptr (theta_ri_ifft));    /* IFFT */
+
+  /* pointwise multiplication with sig vector */
+  for (size_t i = 0; i < M; i++)
+    {
+      double sign;
+      if (i % (M/2) == 0)
+        {
+          sign = 0;
+        }
+      else if (i < M/2)
+        {
+          sign = 1;
+        }
+      else
+        {
+          sign = -1;
+        }
+      sign /= M; // FIXME: should be done by fft wrapper
+      theta_ri_ifft[i] *= sign;
+    }
+  gsl_power2_fftac (M, complex_ptr (theta_ri_ifft), complex_ptr (theta_ri));   /* FFT */
+
+  for (size_t i = 0; i < M; i++)
+    {
+      /* multiplication with -j */
+      theta_ri[i] *= complex<double> (0, -1);
+    }
+
+  // so far, we have computed
+  // theta[i] = -j * DFT (sign[i] * IDFT (a[i]))
+
+  vector<complex<double>> minphase_spect (M);
+  for (size_t i = 0; i < M; i++)
+    {
+      /* |X[i]| * exp(j*t(i)) */
+      complex<double> j (0, 1);
+      minphase_spect[i] = mag_ri[i].real() * exp (j * theta_ri[i]);
+    }
+
+  vector<complex<double>> minphase_fir (M);
+  vector<double> minphase (N);
+  gsl_power2_fftsc (M, complex_ptr (minphase_spect), complex_ptr (minphase_fir));   /* IFFT */
+  for (size_t i = 0; i < M; i++)
+    {
+      if (trace)
+        printf ("# minphase_fir[%zd] = %f %f\n", i, minphase_fir[i].real(), minphase_fir[i].imag());
+
+      if (i < minphase.size())
+        {
+          minphase[i] = minphase_fir[i].real() / M;
+          if (trace)
+            printf ("%f #Fout\n", minphase[i]);
+        }
+    }
+
+  if (trace)
+    {
+      /* minimum phase filter magnitude response */
+      print_fir_response (minphase, "Hout");
+
+      print_fir_response (repeat_n (16, minphase), "Hrep");
+      print_fir_response (interp_linear (16, minphase), "Hlin");
+    }
+  else
+    {
+      printf ("// this file was generated by designblep\n");
+      printf ("#include \"bleposc.hh\"\n");
+      printf ("const float Bse::BlepUtils::OscImpl::blep_delta[%zd] = {\n", minphase.size() + 1);
+    }
+
+  double blep_acc = 0;
+  for (size_t i = 0; i < minphase.size(); i++)
+    {
+      blep_acc += minphase[i];
+      if (trace)
+        printf ("%.17g #blep\n", blep_acc);
+      else
+        printf ("  %.17g,\n", 1 - blep_acc);
+    }
+
+  if (!trace)
+    {
+      printf ("  0\n");
+      printf ("};\n");
+    }
+}

--- a/devices/blepsynth/linearsmooth.hh
+++ b/devices/blepsynth/linearsmooth.hh
@@ -1,0 +1,60 @@
+// Licensed GNU LGPL v2.1 or later: http://www.gnu.org/licenses/lgpl.html
+#ifndef __BSE_DEVICES_LINEAR_SMOOTH_HH__
+#define __BSE_DEVICES_LINEAR_SMOOTH_HH__
+
+/* from liquidsfz utils */
+
+#include <math.h>
+
+#include <string>
+
+namespace Bse {
+
+class LinearSmooth
+{
+  float value_ = 0;
+  float linear_value_ = 0;
+  float linear_step_ = 0;
+  uint  total_steps_ = 1;
+  uint  steps_ = 0;
+public:
+  void
+  reset (uint rate, float time)
+  {
+    total_steps_ = std::max<int> (rate * time, 1);
+  }
+  void
+  set (float new_value, bool now = false)
+  {
+    if (now)
+      {
+        steps_ = 0;
+        value_ = new_value;
+      }
+    else if (new_value != value_)
+      {
+        if (!steps_)
+          linear_value_ = value_;
+
+        linear_step_ = (new_value - linear_value_) / total_steps_;
+        steps_ = total_steps_;
+        value_ = new_value;
+      }
+  }
+  float
+  get_next()
+  {
+    if (!steps_)
+      return value_;
+    else
+      {
+        steps_--;
+        linear_value_ += linear_step_;
+        return linear_value_;
+      }
+  }
+};
+
+}
+
+#endif /* __BSE_DEVICES_LINEAR_SMOOTH_HH__ */

--- a/devices/blepsynth/plotblep.py
+++ b/devices/blepsynth/plotblep.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Licensed GNU LGPL v3 or later: http://www.gnu.org/licenses/lgpl.html
+
+# coding=utf-8
+
+import sys
+import subprocess
+import math
+
+from PyQt5 import QtGui, QtCore, QtWidgets
+
+def clamp (value, minv, maxv):
+  if value < minv:
+    return minv
+  if value > maxv:
+    return maxv
+  return value
+
+def get_delta (x):
+  start = 0
+  y = []
+  for value in x:
+    y.append (value - start)
+    start = value
+  return y
+
+def leaky_integrate (x):
+  out_value = 0
+  y = []
+  for in_value in x:
+    out_value = out_value * 0.9995 + in_value
+    y.append (out_value)
+  return y
+
+def get_dc (x):
+  dc = 0
+  for value in x:
+    dc += value
+  dc = abs (dc) / len (x)
+  if dc > 0:
+    return 20 * math.log10 (dc)
+  else:
+    return -200 # avoid division by zero
+
+def osc_py (params):
+  pulse_width = clamp (params["pulse"].value / 100., 0.01, 0.99)
+  sub = params["sub"].value / 100.
+  shape = params["shape"].value / 100.
+  sub_width = clamp (params["subw"].value / 100., 0.01, 0.99)
+  sub_width = 1 - sub_width
+  sync_factor = 2.0 ** (params["sync"].value / 12.)
+  out = []
+  pos = 0
+  master_phase = 0
+  sub_phase = 0
+  a = (1 - sub_width) * pulse_width
+  c = a + sub_width
+  b = c - sub_width * pulse_width
+  print ("pw1=%.3f" % (a / (1 - sub_width)))
+  print ("pw2=%.3f" % ((c - b) / sub_width))
+  print ("sub=%.3f" % (c - a))
+  print ("a=%f" % a)
+  print ("b=%f" % b)
+  print ("c=%f" % c)
+  while pos < 4800:
+    pos += 1
+
+    master_phase += 0.0005
+    if master_phase > 1:
+      master_phase -= 1
+      sub_phase = 0  # not really correct (see bleposc.hh for a better implementation)
+
+    sub_phase += 0.0005 * sync_factor
+    saw_state = -4 * sub_phase * (shape + 1)
+    if sub_phase > 1:
+      sub_phase -= 1
+
+    if sub_phase > c:
+      pout = shape * 4 + 3
+      sout = 1
+    elif sub_phase > b:
+      pout = shape * 2 + 3
+      sout = -1
+    elif sub_phase > a:
+      pout = shape * 2 + 1
+      sout = -1
+    else:
+      pout = 1
+      sout = 1
+
+    out.append (saw_state * (1 - sub) + pout * (1 - sub) + sout * sub)
+
+  # out = leaky_integrate (get_delta (out)) # simulate blit integration
+  return out
+
+def osc_cxx (params):
+  process = subprocess.Popen(['testblep', 'plotblep',
+    "%.5f" % params["shape"].value,
+    "%.5f" % params["sync"].value,
+    "%.5f" % params["sub"].value,
+    "%.5f" % params["pulse"].value,
+    "%.5f" % params["subw"].value], stdout=subprocess.PIPE)
+  out, err = process.communicate()
+  plot_data = []
+  for o in out.splitlines():
+    plot_data += [ float (o) ]
+  return plot_data
+
+class BlepWidget(QtWidgets.QWidget):
+  def __init__(self):
+    super(BlepWidget, self).__init__()
+    self.setMinimumSize (100, 100)
+
+  def update_params (self, params, cxx):
+    try:
+      if cxx:
+        self.plot_data = osc_cxx (params)
+      else:
+        self.plot_data = osc_py (params)
+      print ("dc=%f dB" % get_dc (self.plot_data[2000:4000]))
+      self.repaint()
+    except KeyError:
+      # hacky way of avoiding to run testblep if not all params are known
+      pass
+
+  def paintEvent(self, event):
+    qp = QtGui.QPainter()
+    qp.begin(self)
+    qp.fillRect (event.rect(), QtGui.QColor (255, 255, 255));
+    xgreycolor = QtGui.QColor (240, 240, 240)
+    qp.fillRect (QtCore.QRect (0, 0, self.width() / 10, self.height()), xgreycolor)
+    qp.fillRect (QtCore.QRect (self.width() * 9 / 10, 0, self.width(), self.height()), xgreycolor)
+    xscale = self.width() / 2000 / 1.25
+    xcenter = -self.width() / 5 * 3.5
+    yscale = -self.height() / 4 * 0.75
+    ycenter = self.height() / 2
+    qp.setPen (QtGui.QColor (190, 190, 190))
+    qp.drawLine (0, ycenter + 1 * yscale, self.width(), ycenter + 1 * yscale)
+    qp.drawLine (0, ycenter + -1 * yscale, self.width(), ycenter + -1 * yscale)
+    qp.drawLine (self.width() / 2, 0, self.width() / 2, self.height())
+    qp.setPen (QtCore.Qt.black)
+    for i in range (len (self.plot_data) - 1):
+      qp.drawLine (i * xscale + xcenter, self.plot_data[i] * yscale + ycenter, (i + 1) * xscale + xcenter, self.plot_data[i+1] * yscale + ycenter)
+
+    qp.setPen (QtGui.QColor(168, 34, 3))
+    qp.drawLine (0, ycenter, self.width(), ycenter)
+
+    qp.end()
+
+class Param:
+  pass
+
+class PlotWindow (QtWidgets.QMainWindow):
+  def __init__ (self):
+    QtWidgets.QMainWindow.__init__(self)
+
+    self.init_ui()
+
+  def init_ui (self):
+    central_widget = QtWidgets.QWidget (self)
+    self.grid_layout = QtWidgets.QGridLayout()
+
+    self.blep_widget = BlepWidget ()
+    self.grid_layout.addWidget (self.blep_widget, 1, 0, 3, 1)
+    central_widget.setLayout (self.grid_layout)
+    self.setCentralWidget (central_widget)
+
+    self.source_button = QtWidgets.QPushButton ("Source: CXX/Py")
+
+    self.params = dict()
+    self.add_slider (1, "shape", 0, -100, 100)
+    self.add_slider (2, "sync", 0, 0, 60)
+    self.add_slider (3, "pulse", 50, 0, 100)
+    self.add_slider (4, "sub", 0, 0, 100)
+    self.add_slider (5, "subw", 50, 0, 100)
+    self.source_button.setCheckable (True)
+    self.source_button.checkable = True
+    self.source_button.clicked.connect (self.on_source_clicked)
+    self.grid_layout.addWidget (self.source_button, 4, 0, 1, 6)
+
+  def add_slider (self, row, label, vdef, vmin, vmax):
+    slider = QtWidgets.QSlider (QtCore.Qt.Vertical)
+    slider.setRange (vmin * 10, vmax * 10)
+    slider.setValue (vdef * 10)
+    slider.setEnabled (True)
+    slider.valueChanged.connect (lambda value: self.on_param_changed (label, value))
+    self.params[label] = Param()
+    self.params[label].value_label = QtWidgets.QLabel()
+    self.on_param_changed (label, vdef * 10)
+    self.grid_layout.addWidget (slider, 3, row, 1, 1, QtCore.Qt.AlignHCenter)
+
+    self.grid_layout.addWidget (QtWidgets.QLabel (label), 1, row, 1, 1, QtCore.Qt.AlignHCenter)
+    self.grid_layout.addWidget (self.params[label].value_label, 2, row, 1, 1, QtCore.Qt.AlignHCenter)
+    self.grid_layout.setColumnStretch (0, 1)
+
+  def on_param_changed (self, label, value):
+    self.params[label].value = value / 10
+    self.params[label].value_label.setText ("%s" % self.params[label].value)
+    self.blep_widget.update_params (self.params, self.source_button.isChecked())
+
+  def on_source_clicked (self):
+    self.blep_widget.update_params (self.params, self.source_button.isChecked())
+
+def main():
+  app = QtWidgets.QApplication (sys.argv)
+  plot = PlotWindow()
+  plot.show()
+  sys.exit (app.exec_())
+
+if __name__ == "__main__":
+  main()

--- a/devices/blepsynth/testblep.cpp
+++ b/devices/blepsynth/testblep.cpp
@@ -1,0 +1,757 @@
+// Licensed GNU LGPL v2.1 or later: http://www.gnu.org/licenses/lgpl.html
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <sys/time.h>
+#include <bse/gslfft.hh>
+#include <bse/bsemathsignal.hh>
+#include <vector>
+#include <complex>
+#include "bleputils.hh"
+#include "bleposc.hh"
+
+using namespace Bse::BlepUtils;
+
+using std::vector;
+using std::string;
+using std::complex;
+using std::max;
+using std::min;
+
+static double *
+complex_ptr (vector<complex<double>>& vec)
+{
+  return reinterpret_cast<double *> (&vec[0]);
+}
+
+enum class DCTest {
+  OFF,
+  ON
+};
+
+static vector<double>
+compute_fft_mag (Osc& o, size_t N, DCTest dc_test)
+{
+  size_t OVER = 8;
+  vector<complex<double>> in_ri (N * OVER), out_ri (N * OVER);
+
+  if (dc_test == DCTest::OFF)
+    {
+      // skip possible dc at start
+      for (size_t i = 0; i < 4 * N; i++)
+        o.process_sample();
+    }
+  for (size_t i = 0; i < N; i++)
+    {
+      in_ri[i] = o.process_sample();
+    }
+
+  double win_norm = 0;
+  for (size_t i = 0; i < N; i++)
+    {
+      const double win = window_kaiser ((i * 2.0 - N) / (N - 1), 4);
+
+      in_ri[i] *= win;
+      win_norm += win;
+    }
+
+  for (size_t i = 0; i < N; i++)
+    {
+      in_ri[i] *= 2.0 / win_norm;
+    }
+
+  gsl_power2_fftac (N * OVER, complex_ptr (in_ri), complex_ptr (out_ri));
+
+  vector<double> out;
+  for (auto ri : out_ri)
+    out.push_back (std::abs (ri));
+
+  return out;
+}
+
+struct SNR
+{
+  double snr;
+  double freq;
+};
+
+static SNR fft_snr (Osc& o, DCTest dc_test);
+
+static void
+print_fft (Osc& o, size_t N, DCTest dc_test)
+{
+  vector<double> mag = compute_fft_mag (o, N, dc_test);
+
+  for (size_t i = 0; i <= mag.size() / 2; i++)
+    {
+      double d = i / double (mag.size()) * o.rate;
+      printf ("%.17g %.17g\n", d, mag[i]);
+    }
+  SNR snr = fft_snr (o, dc_test);
+  printf ("#fft_snr: %f dB @ %f\n", snr.snr, snr.freq);
+}
+
+static void
+get_sig_noise_max (vector<double> mag, /* deep copy to allow destructive processing */
+                   Osc& o,
+                   double& sig_max,
+                   double& noise_max,
+                   double& freq_max)
+{
+  sig_max = 0;
+
+  const double sub_freq = o.master_freq * 0.5;
+  for (float freq = sub_freq; freq < o.rate; freq += sub_freq)
+    {
+      int pos = freq / o.rate * mag.size();
+      for (int i = -32; i < 33; i++)
+        {
+          if (pos + i >= 0 && pos + i < int (mag.size()))
+            {
+              sig_max = std::max (mag[pos + i], sig_max);
+              mag[pos + i] = 0;
+            }
+        }
+    }
+
+  noise_max = 0;
+  freq_max = -1;
+
+  for (size_t i = 0; i <= mag.size() / 2; i++)
+    {
+      double freq = i / double (mag.size()) * o.rate;
+
+      if (freq < 16000) // audible frequencies
+        {
+          double noise_mag = std::abs (mag[i]);
+          if (noise_mag > noise_max)
+            {
+              noise_max = noise_mag;
+              freq_max  = freq;
+           }
+        }
+    }
+}
+
+static SNR
+fft_snr (Osc& o, DCTest dc_test)
+{
+  vector<double> mag = compute_fft_mag (o, 8192, dc_test);
+
+  /* this is required because the width of the window is hardcoded to [-32:32] in get_sig_noise_max() */
+  assert (mag.size() == 8192 * 8);
+
+  double sig_max, noise_max, freq_max;
+  get_sig_noise_max (mag, o, sig_max, noise_max, freq_max);
+
+  SNR snr;
+  snr.snr = bse_db_from_factor (sig_max / noise_max, -200);
+  snr.freq = freq_max;
+
+  return snr;
+}
+
+static void
+auto_snr_test (DCTest dc_test)
+{
+  GRand *rand = g_rand_new_with_seed (42);
+
+  for (int i = 0; i < 1000; i++)
+    {
+      Osc o;
+      o.rate = 48000;
+      o.shape = g_rand_double_range (rand, -1, 1);
+      o.master_freq = g_rand_double_range (rand, 200, 5000);
+      o.freq = g_rand_double_range (rand, o.master_freq, 20000);
+      o.pulse_width = g_rand_double_range (rand, 0.01, 0.99);
+      o.sub = g_rand_double_range (rand, 0, 1);
+      o.sub_width = g_rand_double_range (rand, 0.01, 0.99);
+
+      SNR snr = fft_snr (o, dc_test);
+
+      printf ("%f %f %f %f Y %f sub %f pw %f sw %f sfreq %f\n", snr.snr, o.shape, o.master_freq, o.freq, log2 (o.freq / o.master_freq) * 12, o.sub, o.pulse_width, o.sub_width, snr.freq);
+    }
+}
+
+static SNR
+snr_high_fft (Osc& o, Osc& o_high, int over)
+{
+  vector<double> mag_low = compute_fft_mag (o, 8192, DCTest::OFF);
+  vector<double> mag_high = compute_fft_mag (o_high, 8192 * over, DCTest::OFF);
+
+  if (0)
+    {
+      for (size_t i = 0; i <= mag_low.size() / 2; i++)
+        {
+          double d = i / double (mag_low.size()) * o.rate;
+          printf ("%.17g %.17g #low\n", d, mag_low[i]);
+        }
+      for (size_t i = 0; i <= mag_high.size() / 2; i++)
+        {
+          double d = i / double (mag_high.size()) * o_high.rate;
+          printf ("%.17g %.17g #high\n", d, mag_high[i]);
+        }
+    }
+  double sig_max_low, noise_max_low, sig_max_high, noise_max_high, freq_max_low, freq_max_high;
+
+  get_sig_noise_max (mag_low, o, sig_max_low, noise_max_low, freq_max_low);
+  get_sig_noise_max (mag_high, o_high, sig_max_high, noise_max_high, freq_max_high);
+
+  double sig_max = max (sig_max_low, sig_max_high);
+
+  SNR snr;
+  snr.snr = bse_db_from_factor (sig_max / noise_max_low, -200);
+  snr.freq = freq_max_low;
+  return snr;
+}
+
+static void
+auto_snr_high_test()
+{
+  GRand *rand = g_rand_new_with_seed (42);
+
+  for (int i = 0; i < 1000; i++)
+    {
+      Osc o, o_high;
+
+      o.rate = 48000;
+      o.shape = g_rand_double_range (rand, -1, 1);
+      o.master_freq = g_rand_double_range (rand, 200, 5000);
+      o.freq = g_rand_double_range (rand, o.master_freq, o.master_freq * 30);
+      o.pulse_width = g_rand_double_range (rand, 0.01, 0.99);
+      o.sub = g_rand_double_range (rand, 0, 1);
+      o.sub_width = g_rand_double_range (rand, 0.01, 0.99);
+
+      const int over = 4;
+      o_high.rate = 48000 * over;
+      o_high.shape = o.shape;
+      o_high.master_freq = o.master_freq;
+      o_high.freq = o.freq;
+      o_high.pulse_width = o.pulse_width;
+      o_high.sub = o.sub;
+      o_high.sub_width = o.sub_width;
+
+      SNR snr = snr_high_fft (o, o_high, over);
+
+      printf ("%f %d %f %f %f Y %f sub %f pw %f sw %f sfreq %f\n", snr.snr, i, o.shape, o.master_freq, o.freq, log2 (o.freq / o.master_freq) * 12, o.sub, o.pulse_width, o.sub_width, snr.freq);
+    }
+}
+
+static double
+gettime()
+{
+  timeval tv;
+  gettimeofday (&tv, 0);
+
+  return tv.tv_sec + tv.tv_usec / 1000000.0;
+}
+
+double speed_test_x;
+
+static void
+speed_test (Osc& o)
+{
+  double time = 1e9;
+  const int rate = 48000;
+  const int len  = 32;
+
+  for (int r = 0; r < 10; r++)
+    {
+      const double start = gettime();
+
+      for (int i = 0; i < rate * len; i++)
+        speed_test_x += o.process_sample();
+
+      const double end = gettime();
+      time = min (time, end - start);
+    }
+
+  printf ("%.7f voices   |  %.3f ns/sample\n", len / time, time * 1e9 / (rate * len));
+}
+
+static void
+speed2_test()
+{
+  const int len  = 64;
+
+  OscImpl o;
+
+  float random_buffer[len];
+  for (int n = 0; n < len; n++)
+    random_buffer[n] = g_random_double_range (-1, 1);
+
+  for (int subtest = 0; subtest < 8; subtest++)
+    {
+      o.set_rate (48000);
+      o.frequency_base = 440;
+      o.freq_mod_octaves = 0.00001;
+      o.shape_base = 0; // saw
+      o.shape_mod = 0.00001;
+      o.sync_base = 20;
+      o.sync_mod = 0.00001;
+      o.pulse_width_base = 0.5;
+      o.pulse_width_mod  = 0.00001;
+      o.sub_width_base = 0.5;
+      o.sub_width_mod  = 0.00001;
+
+      float freq_buffer[len];
+      for (int n = 0; n < len; n++)
+        freq_buffer[n] = BSE_SIGNAL_FROM_FREQ (o.frequency_base);
+
+      float *freq_in = nullptr;
+      float *freq_mod = nullptr;
+      float *shape_mod = nullptr;
+      float *sub_mod = nullptr;
+      float *sync_mod = nullptr;
+      float *pulse_width_mod = nullptr;
+      float *sub_width_mod = nullptr;
+      const char *label = nullptr;
+      int unison = 1;
+
+      switch (subtest)
+        {
+          case 0: label = "440y3";
+                  break;
+          case 1: label = "440y3+pw";
+                  pulse_width_mod = random_buffer;
+                  break;
+          case 2: label = "440y3+pw+y";
+                  pulse_width_mod = random_buffer;
+                  sync_mod = random_buffer;
+                  break;
+          case 3: label = "440y3+f";
+                  freq_in = freq_buffer;
+                  break;
+          case 4: label = "440y3+all";
+                  freq_in = freq_buffer;
+                  freq_mod = random_buffer;
+                  shape_mod = random_buffer;
+                  sub_mod = random_buffer;
+                  sync_mod = random_buffer;
+                  pulse_width_mod = random_buffer;
+                  sub_width_mod = random_buffer;
+                  break;
+          case 5: label = "440";
+                  o.sync_base = 0;
+                  break;
+          case 6: label = "440y3+u7";
+                  unison = 7;
+                  break;
+          case 7: label = "440y3+y+u7";
+                  sync_mod = random_buffer;
+                  unison = 7;
+                  break;
+        }
+      if (unison > 1)
+        o.set_unison (unison, 10.0, 1);
+
+      double time = 1e9;
+
+      const int blocks = 10000 / unison;
+
+      for (int r = 0; r < 10; r++)
+        {
+          const double start = gettime();
+
+          for (int i = 0; i < blocks; i++)
+            {
+              float lbuffer[len];
+              float rbuffer[len];
+              o.process_sample_stereo (lbuffer, rbuffer, len,
+                                       freq_in,
+                                       freq_mod,
+                                       shape_mod,
+                                       sub_mod,
+                                       sync_mod,
+                                       pulse_width_mod,
+                                       sub_width_mod);
+
+              for (int n = 0; n < len; n++)
+                speed_test_x += lbuffer[n] + rbuffer[n];
+            }
+
+          const double end = gettime();
+          time = min (time, end - start);
+        }
+
+      printf ("%d  %8.3f voices   |  %7.3f ns/sample    | %s\n", subtest, (len * blocks * unison) / o.rate() / time, time * 1e9 / (len * blocks * unison), label);
+    }
+}
+
+static vector<float>
+dc_reduce (const vector<float>& signal,
+           size_t len)
+{
+  vector<float> dcs;
+
+  for (size_t start = 0; start + len < signal.size(); start += len / 4)
+    {
+      double win_sum = 0;
+      double sum = 0;
+      for (size_t i = 0; i < len; i++)
+        {
+          double win = bse_window_cos ((i * 2.0) / len - 1.0);
+          win_sum += win;
+          sum += signal[start + i] * win;
+          //printf ("%zd %f\n", i, signal[i] * win);
+        }
+      //printf ("%f %f %f\n", start / 48., sum / win_sum);
+      dcs.push_back (sum / win_sum);
+    }
+  return dcs;
+}
+
+static string
+dc_report (vector<float>& dcs)
+{
+  double dmin = 100;
+  double dmax = 0;
+  double davg = 0;
+
+  for (auto d : dcs)
+    {
+      d = fabs (d);
+      dmin = min<double> (d, dmin);
+      dmax = max<double> (d, dmax);
+      davg += d / dcs.size();
+    }
+  return Bse::string_format ("avg %f range [%f, %f]", bse_db_from_factor (fabs (davg), -200), bse_db_from_factor (fabs (dmin), -200), bse_db_from_factor (fabs (dmax), -200));
+}
+
+static void
+lfo_test (int dump = -1)
+{
+  const int len = 48000;
+
+  OscImpl o;
+
+  for (int subtest = 0; subtest < 4; subtest++)
+    {
+      string label;
+
+      o.set_rate (48000);
+      o.frequency_base = 440;
+      o.shape_base = 0; // saw
+      o.sync_base = 0;
+      o.pulse_width_base = 0.5;
+      o.sub_width_base = 0.5;
+
+      float lfo[len];
+
+      float *freq_in = nullptr;
+      float *freq_mod_in = nullptr;
+      float *shape_mod_in = nullptr;
+      float *sub_mod_in = nullptr;
+      float *sync_mod_in = nullptr;
+      float *pulse_width_mod_in = nullptr;
+      float *sub_width_mod_in = nullptr;
+
+      switch (subtest)
+        {
+          case 0: o.shape_base = -1;
+                  o.pulse_width_mod = 0.48;
+                  pulse_width_mod_in = lfo;
+                  label = "pulse";
+                  break;
+          case 1: o.shape_base = -1;
+                  o.sub_width_base = 0.95;
+                  o.sub_base = 0.5;
+                  o.sub_mod = 0.5;
+                  sub_mod_in = lfo;
+                  label = "subm";
+                  break;
+          case 2: o.pulse_width_base = 0.9;
+                  o.shape_base = 0;
+                  o.shape_mod = 1;
+                  shape_mod_in = lfo;
+                  label = "shape";
+                  break;
+          case 3: o.shape_base = -1;
+                  o.sub_width_base = 0.95;
+                  o.sub_base = 0.5;
+                  o.sub_mod = 0.5;
+                  o.sync_base = 30;
+                  sub_mod_in = lfo;
+                  label = "subm+sync";
+                  break;
+        }
+
+      float lfo_hz = 5;
+      for (int i = 0; i < len; i++)
+        lfo[i] = sin (i * lfo_hz * 2 * M_PI / 48000.);
+
+      vector<float> lbuffer (len);
+      vector<float> rbuffer (len);
+      o.process_sample_stereo (&lbuffer[0], &rbuffer[0], len, freq_in, freq_mod_in, shape_mod_in, sub_mod_in, sync_mod_in, pulse_width_mod_in, sub_width_mod_in);
+
+      for (int i = 0; i < len; i++)
+        {
+          assert (fabs (lbuffer[i] - rbuffer[i]) < 0.0001);
+          if (dump == subtest)
+            printf ("%f\n", lbuffer[i] * 0.2);
+        }
+      if (dump == -1)
+        {
+          vector<float> dcs = dc_reduce (lbuffer, 4096);
+          printf ("%d %s: %s\n", subtest, label.c_str(), dc_report (dcs).c_str());
+          dc_report (dcs);
+        }
+    }
+}
+
+
+template<int FN> double
+exp2_func (double d)
+{
+  switch (FN)
+  {
+    case 0: return pow (2, d);
+    case 1: return exp (d * 0.693147180559945);
+    case 2: return bse_approx2_exp2 (d);
+    case 3: return bse_approx3_exp2 (d);
+    case 4: return bse_approx4_exp2 (d);
+    case 5: return bse_approx5_exp2 (d);
+    case 6: return bse_approx6_exp2 (d);
+    case 7: return bse_approx7_exp2 (d);
+    case 8: return bse_approx8_exp2 (d);
+    case 9: return bse_approx9_exp2 (d);
+  }
+}
+template<int FN> std::string
+exp2_label()
+{
+  switch (FN)
+  {
+    case 0: return "pow";
+    case 1: return "exp";
+    default: return Bse::string_format ("approx%d_exp2", FN);
+  }
+}
+
+template<int FN> void
+exp2_subtest()
+{
+  double time = 1e9;
+  const int len  = 1'000'000;
+
+  // speed
+  for (int runs = 0; runs < 32; runs++)
+    {
+      const double start = gettime();
+      for (int i = 0; i < len; i++)
+        {
+          double d = double (i) / len;
+          speed_test_x += exp2_func<FN> (d);
+        }
+      const double end = gettime();
+      time = min (time, end - start);
+    }
+
+  // accuracy
+  double err = 0;
+  for (double d = -5; d < 5; d += 0.0001)
+    {
+      err = max (err, fabs (exp2_func<FN> (d) - pow (2, d)) / pow (2, d));
+    }
+  printf ("%15s  %6.3f ns   err=%5.2g\n", exp2_label<FN>().c_str(), time * 1e9 / len, err);
+}
+
+static void
+exp2_test()
+{
+  exp2_subtest<0>();
+  exp2_subtest<1>();
+  exp2_subtest<2>();
+  exp2_subtest<3>();
+  exp2_subtest<4>();
+  exp2_subtest<5>();
+  exp2_subtest<6>();
+  exp2_subtest<7>();
+  exp2_subtest<8>();
+  exp2_subtest<9>();
+}
+
+static void
+vnorm_test (Osc& o)
+{
+  const int rate = 48000;
+  const int len  = 32;
+
+  for (int n_voices = 1; n_voices < 16; n_voices++)
+    {
+      for (int stereo = 0; stereo < 5; stereo++)
+        {
+          o.set_unison (n_voices, 15, stereo / 4.0);
+
+          double eleft = 0, eright = 0;
+          for (int i = 0; i < rate * len; i++)
+            {
+              float vleft, vright;
+
+              o.process_sample_stereo (&vleft, &vright);
+
+              eleft  += vleft * vleft;
+              eright += vright * vright;
+            }
+          printf ("%d %d %f %f\n", stereo, n_voices, 10 * log10 (eleft / (rate * len)), 10 * log10 (eright / (rate * len)));
+        }
+    }
+}
+
+static void
+reset_test (Osc& o)
+{
+  for (int rpos = 0; rpos <= 10; rpos++)
+    {
+      double r = rpos / 10.;
+
+      o.osc_impl.reset(); // clear future
+      o.osc_impl.reset_master (o.osc_impl.unison_voices[0], r);
+
+      double t = r * o.rate / (o.master_freq * 0.5);
+      for (int l = 0; l < 4000; l++)
+        printf ("%.17g %.17g #%d\n", t++, o.process_sample(), rpos);
+    }
+}
+
+static void
+plot_blep (float shape, float sync, float sub, float pulse, float sub_width)
+{
+  Osc o;
+  o.rate = 48000;
+  o.pulse_width = pulse / 100;
+  o.shape = shape / 100;
+  o.sub = sub / 100;
+  o.sub_width = sub_width / 100;
+  o.master_freq = 48;
+  o.freq = pow (2, sync / 12) * o.master_freq; /* sync param: semitones */
+
+  for (int i = 0; i < 4800; i++)
+    {
+      printf ("%.17g\n", o.process_sample());
+    }
+#if 0
+  for (int i = 0; i < 4800; i++)
+    {
+      printf ("%17g\n", o.test_seek_to ((i % 2000) / 2000.));
+    }
+#endif
+}
+
+static void
+dc_test (Osc& o)
+{
+  for (int sec = 0; sec < 4; sec++)
+    {
+      double dc = 0;
+      for (int i = 0; i < o.rate; i++)
+        dc += o.process_sample();
+      dc /= o.rate;
+      printf ("%d %.6f %.17g #dB\n", sec, dc, bse_db_from_factor (fabs (dc), -200));
+    }
+}
+
+int
+main (int argc, char **argv)
+{
+  Osc o;
+  o.rate = 48000;
+  o.pulse_width = 0.5;
+  o.shape = 0; // saw
+  o.freq = 440 * 3.1;
+  o.master_freq = 440;
+
+#if 0
+  /* dc problem */
+// 36.782045 0.563029 4174.116241 16051.472457 Y 23.317956 pw 0.793546 sw 0.818630 sfreq 5.859375
+  o.rate = 48000;
+  o.shape = 0.563029;
+  o.freq = 16051.472457;
+  o.master_freq = 4174.116241;
+  o.pulse_width = 0.793546;
+  o.sub_width = 0.818630;
+#endif
+#if 0
+  /* sync bug */
+  o.shape = 0;
+  o.freq = 1150 * 1.97;
+  o.master_freq = 1150;
+#endif
+#if 0
+  /* sync bug */
+  o.shape = 1;
+  o.freq = 1150 * 1.48;
+  o.master_freq = 1150;
+#endif
+#if 0
+  /* pulse bug */
+  o.shape = 1;
+  o.freq = 17540;
+  o.master_freq = 2440;
+  o.pulse_width = 0.01;
+#endif
+#if 0
+  // to get better speed test results:
+  //
+  // g++ -O2 -o tb testblep.cc bleposcdata.cc $(pkg-config --cflags --libs bse) -std=c++11
+  //
+  // and: run only speed test
+  speed_test (o);
+  return 0;
+#endif
+
+  if (argc == 7 && strcmp (argv[1], "plotblep") == 0)
+    {
+      plot_blep (atof (argv[2]), atof (argv[3]), atof (argv[4]), atof (argv[5]), atof (argv[6]));
+      return 0;
+    }
+  if (argc == 3 && strcmp (argv[1], "lfo") == 0)
+    {
+      lfo_test (atoi (argv[2]));
+      return 0;
+    }
+  if (argc == 2)
+    {
+      string test_name = argv[1];
+
+      if (test_name == "vnorm")
+        vnorm_test (o);
+      else if (test_name == "fft")
+        print_fft (o, 8192, DCTest::OFF);
+      else if (test_name == "fft-dc")
+        print_fft (o, 8192, DCTest::ON);
+      else if (test_name == "speed")
+        speed_test (o);
+      else if (test_name == "speed2")
+        speed2_test();
+      else if (test_name == "snr")
+        auto_snr_test (DCTest::OFF);
+      else if (test_name == "snr-dc")
+        auto_snr_test (DCTest::ON);
+      else if (test_name == "snr-high")
+        auto_snr_high_test();
+      else if (test_name == "exp2")
+        exp2_test();
+      else if (test_name == "reset")
+        reset_test (o);
+      else if (test_name == "dc")
+        dc_test (o);
+      else if (test_name == "lfo")
+        lfo_test ();
+      else
+        {
+          Bse::printerr ("%s: unsupported test type '%s', try vnorm, fft, speed, speed2, reset, exp2 or snr\n", argv[0], test_name.c_str());
+          return 1;
+        }
+      return 0;
+    }
+
+  //for (o.freq = 20; o.freq < 20000; o.freq *= 1.00003)
+  for (int i = 0; i < 48000; i++)
+    {
+      double sample = o.process_sample();
+
+      printf ("%.17g\n", sample * 0.5);
+    }
+}


### PR DESCRIPTION
Here is a bunch of new stuff for BlepSynth, I won't try to reproduce the commit entries here. Only a few additional observations:

* x^3 non-linear adsr time scaling used to work but now it doesn't probably due to parameter API changes (I didn't try to fix it)
* some parameters (octave, unison voices) need step=1 but I haven't seen how to set it when registering a parameter, so this workarounded a bit by overriding param-to-text conversion and omitting decimals
* new filter envelope is hard-wired to modulate cutoff, whereas it would make sense if it could modulate any parameter, but we don't have the ui for selecting modulation targets yet (nor the infrastructure bits)
