### PR TITLE
LiquidSFZ device

### DIFF
--- a/config-checks.mk
+++ b/config-checks.mk
@@ -92,7 +92,7 @@ config-checks.require.pkgconfig ::= $(strip	\
 # used for GLIB_CFLAGS and GLIB_LIBS
 GLIB_PACKAGES    ::= glib-2.0 gobject-2.0 gmodule-no-export-2.0 zlib
 # used for BSEDEPS_CFLAGS BSEDEPS_LIBS
-BSEDEPS_PACKAGES ::= fluidsynth vorbisenc vorbisfile vorbis ogg flac zlib $(GLIB_PACKAGES) # mad
+BSEDEPS_PACKAGES ::= fluidsynth liquidsfz vorbisenc vorbisfile vorbis ogg flac zlib $(GLIB_PACKAGES) # mad
 # used for BSE_JACK_LIBS
 BSEDEP_JACK     ::= jack >= 0.124.0
 

--- a/devices/liquidsfz/TODO
+++ b/devices/liquidsfz/TODO
@@ -1,0 +1,1 @@
+- reset is not being called after stop, so notes hang (this is a beast bug, not a device bug)

--- a/devices/liquidsfz/liquidsfz.cc
+++ b/devices/liquidsfz/liquidsfz.cc
@@ -50,7 +50,7 @@ class LiquidSFZ : public AudioSignal::Processor {
   void
   reset () override
   {
-    // TODO: reset is not available in liquidsfz API at the moment
+    synth_.system_reset();
 
     adjust_params (true);
   }
@@ -82,7 +82,8 @@ class LiquidSFZ : public AudioSignal::Processor {
             synth_.add_event_note_on (time_stamp, ev.channel, ev.key, std::clamp (bse_ftoi (ev.velocity * 127), 0, 127));
             break;
           case Message::ALL_NOTES_OFF:
-            // TODO: not available in liquidsfz API at the moment
+          case Message::ALL_SOUND_OFF:
+            synth_.all_sound_off();    // NOTE: there is no extra "all notes off" in liquidsfz
             break;
           default: ;
           }

--- a/devices/liquidsfz/liquidsfz.cc
+++ b/devices/liquidsfz/liquidsfz.cc
@@ -76,10 +76,10 @@ class LiquidSFZ : public AudioSignal::Processor {
         switch (ev.message())
           {
           case Message::NOTE_OFF:
-            synth_.add_event_note_off (time_stamp, ev.channel, ev.pitch);
+            synth_.add_event_note_off (time_stamp, ev.channel, ev.key);
             break;
           case Message::NOTE_ON:
-            synth_.add_event_note_on (time_stamp, ev.channel, ev.pitch, std::clamp (bse_ftoi (ev.velocity * 127), 0, 127));
+            synth_.add_event_note_on (time_stamp, ev.channel, ev.key, std::clamp (bse_ftoi (ev.velocity * 127), 0, 127));
             break;
           case Message::ALL_NOTES_OFF:
             // TODO: not available in liquidsfz API at the moment

--- a/devices/liquidsfz/liquidsfz.cc
+++ b/devices/liquidsfz/liquidsfz.cc
@@ -1,0 +1,79 @@
+// Licensed GNU LGPL v2.1 or later: http://www.gnu.org/licenses/lgpl.html
+#include "bse/processor.hh"
+#include "bse/signalmath.hh"
+#include "bse/internal.hh"
+
+#include <liquidsfz.hh>
+
+namespace Bse {
+
+using namespace AudioSignal;
+using LiquidSFZ::Synth;
+
+// == LiquidSFZ ==
+// SFZ sampler using liquidsfz library
+class LiquidSFZ : public AudioSignal::Processor {
+  OBusId stereo_out_;
+  Synth synth_;
+
+  void
+  initialize () override
+  {
+    synth_.set_sample_rate (sample_rate());
+    synth_.load ("/home/stefan/sfz/SalamanderGrandPianoV3_44.1khz16bit/SalamanderGrandPianoV3.sfz");
+    // TODO: handle load error
+  }
+  void
+  query_info (ProcessorInfo &info) override
+  {
+    info.uri = "Bse.LiquidSFZ";
+    // info.version = "0";
+    info.label = "LiquidSFZ";
+    info.category = "Synth";
+  }
+  void
+  configure (uint n_ibusses, const SpeakerArrangement *ibusses, uint n_obusses, const SpeakerArrangement *obusses) override
+  {
+    remove_all_buses();
+    prepare_event_input();
+    stereo_out_ = add_output_bus ("Stereo Out", SpeakerArrangement::STEREO);
+    assert_return (bus_info (stereo_out_).ident == "stereo-out");
+  }
+  void
+  reset () override
+  {
+    // TODO: not available in liquidsfz API at the moment
+  }
+  void
+  render (uint n_frames) override
+  {
+    EventRange erange = get_event_input();
+    for (const auto &ev : erange)
+      {
+        const int time_stamp = std::max<int> (ev.frame, 0);
+        switch (ev.message())
+          {
+          case Message::NOTE_OFF:
+            synth_.add_event_note_off (time_stamp, ev.channel, ev.pitch);
+            break;
+          case Message::NOTE_ON:
+            synth_.add_event_note_on (time_stamp, ev.channel, ev.pitch, std::clamp (bse_ftoi (ev.velocity * 127), 0, 127));
+            break;
+          case Message::ALL_NOTES_OFF:
+            // TODO: not available in liquidsfz API at the moment
+            break;
+          default: ;
+          }
+      }
+
+    float *output[2] = {
+      oblock (stereo_out_, 0),
+      oblock (stereo_out_, 1)
+    };
+    synth_.process (output, n_frames);
+  }
+};
+
+static auto liquidsfz = Bse::enroll_asp<LiquidSFZ>();
+
+} // Bse


### PR DESCRIPTION
Here is an implementation of a LiquidSFZ device. The obvious next step would be allowing the user to specify file. Loading might want to use an extra thread, so that it doesn't block anything.  SFZ files can take a long while to load.