### PR TITLE
LV2 support

### DIFF
--- a/config-checks.mk
+++ b/config-checks.mk
@@ -92,7 +92,7 @@ config-checks.require.pkgconfig ::= $(strip	\
 # used for GLIB_CFLAGS and GLIB_LIBS
 GLIB_PACKAGES    ::= glib-2.0 gobject-2.0 gmodule-no-export-2.0 zlib
 # used for BSEDEPS_CFLAGS BSEDEPS_LIBS
-BSEDEPS_PACKAGES ::= fluidsynth vorbisenc vorbisfile vorbis ogg flac zlib $(GLIB_PACKAGES) # mad
+BSEDEPS_PACKAGES ::= fluidsynth lilv-0 vorbisenc vorbisfile vorbis ogg flac zlib $(GLIB_PACKAGES) # mad
 # used for BSE_JACK_LIBS
 BSEDEP_JACK     ::= jack >= 0.124.0
 

--- a/devices/lv2device/lv2_evbuf.cc
+++ b/devices/lv2device/lv2_evbuf.cc
@@ -1,0 +1,276 @@
+/*
+  Copyright 2008-2016 David Robillard <http://drobilla.net>
+
+  Permission to use, copy, modify, and/or distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THIS SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "lv2/lv2plug.in/ns/ext/atom/atom.h"
+#include "lv2/lv2plug.in/ns/ext/event/event.h"
+
+#include "lv2_evbuf.h"
+
+struct LV2_Evbuf_Impl {
+	LV2_Evbuf_Type type;
+	uint32_t       capacity;
+	uint32_t       atom_Chunk;
+	uint32_t       atom_Sequence;
+	union {
+		LV2_Event_Buffer  event;
+		LV2_Atom_Sequence atom;
+	} buf;
+};
+
+static inline uint32_t
+lv2_evbuf_pad_size(uint32_t size)
+{
+	return (size + 7) & (~7);
+}
+
+LV2_Evbuf*
+lv2_evbuf_new(uint32_t       capacity,
+              LV2_Evbuf_Type type,
+              uint32_t       atom_Chunk,
+              uint32_t       atom_Sequence)
+{
+	// FIXME: memory must be 64-bit aligned
+	LV2_Evbuf* evbuf = (LV2_Evbuf*)malloc(
+		sizeof(LV2_Evbuf) + sizeof(LV2_Atom_Sequence) + capacity);
+	evbuf->capacity      = capacity;
+	evbuf->atom_Chunk    = atom_Chunk;
+	evbuf->atom_Sequence = atom_Sequence;
+	lv2_evbuf_set_type(evbuf, type);
+	lv2_evbuf_reset(evbuf, true);
+	return evbuf;
+}
+
+void
+lv2_evbuf_free(LV2_Evbuf* evbuf)
+{
+	free(evbuf);
+}
+
+void
+lv2_evbuf_set_type(LV2_Evbuf* evbuf, LV2_Evbuf_Type type)
+{
+	evbuf->type = type;
+	switch (type) {
+	case LV2_EVBUF_EVENT:
+		evbuf->buf.event.data     = (uint8_t*)(evbuf + 1);
+		evbuf->buf.event.capacity = evbuf->capacity;
+		break;
+	case LV2_EVBUF_ATOM:
+		break;
+	}
+	lv2_evbuf_reset(evbuf, true);
+}
+
+void
+lv2_evbuf_reset(LV2_Evbuf* evbuf, bool input)
+{
+	switch (evbuf->type) {
+	case LV2_EVBUF_EVENT:
+		evbuf->buf.event.header_size = sizeof(LV2_Event_Buffer);
+		evbuf->buf.event.stamp_type  = LV2_EVENT_AUDIO_STAMP;
+		evbuf->buf.event.event_count = 0;
+		evbuf->buf.event.size        = 0;
+		break;
+	case LV2_EVBUF_ATOM:
+		if (input) {
+			evbuf->buf.atom.atom.size = sizeof(LV2_Atom_Sequence_Body);
+			evbuf->buf.atom.atom.type = evbuf->atom_Sequence;
+		} else {
+			evbuf->buf.atom.atom.size = evbuf->capacity;
+			evbuf->buf.atom.atom.type = evbuf->atom_Chunk;
+		}
+	}
+}
+
+uint32_t
+lv2_evbuf_get_size(LV2_Evbuf* evbuf)
+{
+	switch (evbuf->type) {
+	case LV2_EVBUF_EVENT:
+		return evbuf->buf.event.size;
+	case LV2_EVBUF_ATOM:
+		assert(evbuf->buf.atom.atom.type != evbuf->atom_Sequence
+		       || evbuf->buf.atom.atom.size >= sizeof(LV2_Atom_Sequence_Body));
+		return evbuf->buf.atom.atom.type == evbuf->atom_Sequence
+			? evbuf->buf.atom.atom.size - sizeof(LV2_Atom_Sequence_Body)
+			: 0;
+	}
+	return 0;
+}
+
+void*
+lv2_evbuf_get_buffer(LV2_Evbuf* evbuf)
+{
+	switch (evbuf->type) {
+	case LV2_EVBUF_EVENT:
+		return &evbuf->buf.event;
+	case LV2_EVBUF_ATOM:
+		return &evbuf->buf.atom;
+	}
+	return NULL;
+}
+
+LV2_Evbuf_Iterator
+lv2_evbuf_begin(LV2_Evbuf* evbuf)
+{
+	LV2_Evbuf_Iterator iter = { evbuf, 0 };
+	return iter;
+}
+
+LV2_Evbuf_Iterator
+lv2_evbuf_end(LV2_Evbuf* evbuf)
+{
+	const uint32_t           size = lv2_evbuf_get_size(evbuf);
+	const LV2_Evbuf_Iterator iter = { evbuf, lv2_evbuf_pad_size(size) };
+	return iter;
+}
+
+bool
+lv2_evbuf_is_valid(LV2_Evbuf_Iterator iter)
+{
+	return iter.offset < lv2_evbuf_get_size(iter.evbuf);
+}
+
+LV2_Evbuf_Iterator
+lv2_evbuf_next(LV2_Evbuf_Iterator iter)
+{
+	if (!lv2_evbuf_is_valid(iter)) {
+		return iter;
+	}
+
+	LV2_Evbuf* evbuf  = iter.evbuf;
+	uint32_t   offset = iter.offset;
+	uint32_t   size;
+	switch (evbuf->type) {
+	case LV2_EVBUF_EVENT:
+		size    = ((LV2_Event*)(evbuf->buf.event.data + offset))->size;
+		offset += lv2_evbuf_pad_size(sizeof(LV2_Event) + size);
+		break;
+	case LV2_EVBUF_ATOM:
+		size = ((LV2_Atom_Event*)
+		        ((char*)LV2_ATOM_CONTENTS(LV2_Atom_Sequence, &evbuf->buf.atom)
+		         + offset))->body.size;
+		offset += lv2_evbuf_pad_size(sizeof(LV2_Atom_Event) + size);
+		break;
+	}
+
+	LV2_Evbuf_Iterator next = { evbuf, offset };
+	return next;
+}
+
+bool
+lv2_evbuf_get(LV2_Evbuf_Iterator iter,
+              uint32_t*          frames,
+              uint32_t*          subframes,
+              uint32_t*          type,
+              uint32_t*          size,
+              uint8_t**          data)
+{
+	*frames = *subframes = *type = *size = 0;
+	*data = NULL;
+
+	if (!lv2_evbuf_is_valid(iter)) {
+		return false;
+	}
+
+	LV2_Event_Buffer*  ebuf;
+	LV2_Event*         ev;
+	LV2_Atom_Sequence* aseq;
+	LV2_Atom_Event*    aev;
+	switch (iter.evbuf->type) {
+	case LV2_EVBUF_EVENT:
+		ebuf = &iter.evbuf->buf.event;
+		ev = (LV2_Event*)((char*)ebuf->data + iter.offset);
+		*frames    = ev->frames;
+		*subframes = ev->subframes;
+		*type      = ev->type;
+		*size      = ev->size;
+		*data      = (uint8_t*)ev + sizeof(LV2_Event);
+		break;
+	case LV2_EVBUF_ATOM:
+		aseq = (LV2_Atom_Sequence*)&iter.evbuf->buf.atom;
+		aev = (LV2_Atom_Event*)(
+			(char*)LV2_ATOM_CONTENTS(LV2_Atom_Sequence, aseq)
+			+ iter.offset);
+		*frames    = aev->time.frames;
+		*subframes = 0;
+		*type      = aev->body.type;
+		*size      = aev->body.size;
+		*data      = (uint8_t*)LV2_ATOM_BODY(&aev->body);
+		break;
+	}
+
+	return true;
+}
+
+bool
+lv2_evbuf_write(LV2_Evbuf_Iterator* iter,
+                uint32_t            frames,
+                uint32_t            subframes,
+                uint32_t            type,
+                uint32_t            size,
+                const uint8_t*      data)
+{
+	LV2_Event_Buffer*  ebuf;
+	LV2_Event*         ev;
+	LV2_Atom_Sequence* aseq;
+	LV2_Atom_Event*    aev;
+	switch (iter->evbuf->type) {
+	case LV2_EVBUF_EVENT:
+		ebuf = &iter->evbuf->buf.event;
+		if (ebuf->capacity - ebuf->size < sizeof(LV2_Event) + size) {
+			return false;
+		}
+
+		ev = (LV2_Event*)(ebuf->data + iter->offset);
+		ev->frames    = frames;
+		ev->subframes = subframes;
+		ev->type      = type;
+		ev->size      = size;
+		memcpy((uint8_t*)ev + sizeof(LV2_Event), data, size);
+
+		size               = lv2_evbuf_pad_size(sizeof(LV2_Event) + size);
+		ebuf->size        += size;
+		ebuf->event_count += 1;
+		iter->offset      += size;
+		break;
+	case LV2_EVBUF_ATOM:
+		aseq = (LV2_Atom_Sequence*)&iter->evbuf->buf.atom;
+		if (iter->evbuf->capacity - sizeof(LV2_Atom) - aseq->atom.size
+		    < sizeof(LV2_Atom_Event) + size) {
+			return false;
+		}
+
+		aev = (LV2_Atom_Event*)(
+			(char*)LV2_ATOM_CONTENTS(LV2_Atom_Sequence, aseq)
+			+ iter->offset);
+		aev->time.frames = frames;
+		aev->body.type   = type;
+		aev->body.size   = size;
+		memcpy(LV2_ATOM_BODY(&aev->body), data, size);
+
+		size             = lv2_evbuf_pad_size(sizeof(LV2_Atom_Event) + size);
+		aseq->atom.size += size;
+		iter->offset    += size;
+		break;
+	}
+
+	return true;
+}

--- a/devices/lv2device/lv2device.cc
+++ b/devices/lv2device/lv2device.cc
@@ -1,0 +1,548 @@
+// Licensed GNU LGPL v2.1 or later: http://www.gnu.org/licenses/lgpl.html
+#include "bse/processor.hh"
+#include "bse/signalmath.hh"
+#include "bse/internal.hh"
+
+#include "lv2/lv2plug.in/ns/ext/atom/atom.h"
+#include "lv2/lv2plug.in/ns/ext/midi/midi.h"
+#include "lv2/lv2plug.in/ns/ext/options/options.h"
+#include "lv2/lv2plug.in/ns/ext/parameters/parameters.h"
+#include "lv2/lv2plug.in/ns/ext/buf-size/buf-size.h"
+#include "lv2/lv2plug.in/ns/ext/worker/worker.h"
+
+#include "lv2_evbuf.h"
+
+#include <lilv/lilv.h>
+
+namespace Bse {
+
+using namespace AudioSignal;
+
+namespace
+{
+
+#define NS_EXT "http://lv2plug.in/ns/ext/"
+
+using std::vector;
+using std::string;
+using std::map;
+using std::max;
+using std::min;
+
+class Map
+{
+  LV2_URID              next_id;
+  map<string, LV2_URID> m_urid_map;
+
+  LV2_URID_Map       lv2_urid_map;
+  const LV2_Feature  lv2_urid_map_feature;
+public:
+  Map() :
+    next_id (1),
+    lv2_urid_map { this, urid_map },
+    lv2_urid_map_feature { LV2_URID_MAP_URI, &lv2_urid_map }
+  {
+  }
+
+  static LV2_URID
+  urid_map (LV2_URID_Map_Handle handle, const char *str)
+  {
+    return static_cast<Map *> (handle)->urid_map (str);
+  }
+
+  LV2_URID
+  urid_map (const char *str)
+  {
+    LV2_URID& id = m_urid_map[str];
+    if (id == 0)
+      id = next_id++;
+
+    printf ("map %s -> %d\n", str, id);
+    return id;
+  }
+
+  const LV2_Feature *
+  feature() const
+  {
+    return &lv2_urid_map_feature;
+  }
+};
+
+class PluginHost;
+
+class Options
+{
+  PluginHost& plugin_host;
+  float       m_sample_rate;
+  uint32_t    m_block_length;
+
+  vector<LV2_Options_Option> const_opts;
+
+  LV2_Feature  lv2_options_feature;
+public:
+  Options (PluginHost& plugin_host);
+  void
+  set (float sample_rate, int32_t block_length)
+  {
+    m_sample_rate   = sample_rate;
+    m_block_length  = block_length;
+  }
+  const LV2_Feature *
+  feature() const
+  {
+    return &lv2_options_feature;
+  }
+};
+
+class Worker
+{
+  LV2_Worker_Schedule lv2_worker_sched;
+  const LV2_Feature   lv2_worker_feature;
+public:
+  Worker() :
+    lv2_worker_sched { this, schedule },
+    lv2_worker_feature { LV2_WORKER__schedule, &lv2_worker_sched }
+  {
+  }
+
+  static LV2_Worker_Status
+  schedule (LV2_Worker_Schedule_Handle handle,
+            uint32_t                   size,
+            const void*                data)
+  {
+    printf ("schedule %p %d %p\n", handle, size, data);
+    return LV2_WORKER_ERR_UNKNOWN; // TODO
+  }
+
+  const LV2_Feature *
+  feature() const
+  {
+    return &lv2_worker_feature;
+  }
+};
+
+
+class Features
+{
+  std::vector<const LV2_Feature *> features;
+public:
+  Features()
+  {
+    features.push_back (nullptr);
+  }
+  const LV2_Feature * const*
+  get_features()
+  {
+    return &features[0];
+  }
+  void
+  add (const LV2_Feature *lv2_feature)
+  {
+    // preserve nullptr termination
+    assert_return (!features.empty());
+
+    features.back() = lv2_feature;
+    features.push_back (nullptr);
+  }
+};
+
+struct Port
+{
+  LV2_Evbuf  *evbuf;
+  float       control;    /* for control ports */
+  enum {
+    UNKNOWN,
+    CONTROL_IN,
+    CONTROL_OUT
+  }           type;
+
+  Port() :
+    evbuf (nullptr),
+    control (0.0),
+    type (UNKNOWN)
+  {
+  }
+};
+
+struct PluginInstance
+{
+  PluginHost& plugin_host;
+
+  PluginInstance (PluginHost& plugin_host) :
+    plugin_host (plugin_host)
+  {
+  }
+
+  const LilvPlugin             *plugin;
+  LilvInstance                 *instance;
+  std::vector<Port>             plugin_ports;
+  std::vector<int>              atom_out_ports;
+  std::vector<int>              atom_in_ports;
+  std::vector<int>              audio_in_ports;
+  std::vector<int>              audio_out_ports;
+
+  void init_ports();
+  void reset_event_buffers();
+  void write_midi (uint32_t time, size_t size, const uint8_t *data);
+  void run (float *audio_out_l, float *audio_out_r, uint32_t nframes);
+};
+
+struct PluginHost
+{
+  LilvWorld  *world;
+  Features    features;
+  Map         urid_map;
+
+  struct URIDs {
+    LV2_URID param_sampleRate;
+    LV2_URID atom_Float;
+    LV2_URID atom_Int;
+    LV2_URID atom_eventTransfer;
+    LV2_URID bufsz_maxBlockLength;
+    LV2_URID bufsz_minBlockLength;
+    LV2_URID midi_MidiEvent;
+
+    URIDs (Map& map) :
+      param_sampleRate          (map.urid_map (LV2_PARAMETERS__sampleRate)),
+      atom_Float                (map.urid_map (LV2_ATOM__Float)),
+      atom_Int                  (map.urid_map (LV2_ATOM__Int)),
+      atom_eventTransfer        (map.urid_map (LV2_ATOM__eventTransfer)),
+      bufsz_maxBlockLength      (map.urid_map (LV2_BUF_SIZE__maxBlockLength)),
+      bufsz_minBlockLength      (map.urid_map (LV2_BUF_SIZE__minBlockLength)),
+      midi_MidiEvent            (map.urid_map (LV2_MIDI__MidiEvent))
+    {
+    }
+  } urids;
+
+  struct Nodes {
+    LilvNode *lv2_audio_class;
+    LilvNode *lv2_atom_class;
+    LilvNode *lv2_input_class;
+    LilvNode *lv2_output_class;
+    LilvNode *lv2_control_class;
+
+    LilvNode *lv2_atom_Chunk;
+    LilvNode *lv2_atom_Sequence;
+
+    void init (LilvWorld *world)
+    {
+      lv2_audio_class   = lilv_new_uri (world, LILV_URI_AUDIO_PORT);
+      lv2_atom_class    = lilv_new_uri (world, LILV_URI_ATOM_PORT);
+      lv2_input_class   = lilv_new_uri (world, LILV_URI_INPUT_PORT);
+      lv2_output_class  = lilv_new_uri (world, LILV_URI_OUTPUT_PORT);
+      lv2_control_class = lilv_new_uri (world, LILV_URI_CONTROL_PORT);
+
+      lv2_atom_Chunk    = lilv_new_uri (world, LV2_ATOM__Chunk);
+      lv2_atom_Sequence = lilv_new_uri (world, LV2_ATOM__Sequence);
+    }
+  } nodes;
+
+  Worker   worker;
+  Options  options;
+
+  PluginHost() :
+    world (nullptr),
+    urids (urid_map),
+    options (*this)
+  {
+    world = lilv_world_new();
+    lilv_world_load_all (world);
+
+    nodes.init (world);
+
+    features.add (urid_map.feature());
+    features.add (worker.feature());
+    features.add (options.feature());
+  }
+  PluginInstance *instantiate (const char *plugin_uri, float mix_freq);
+};
+
+Options::Options (PluginHost& plugin_host) :
+  plugin_host (plugin_host),
+  lv2_options_feature { LV2_OPTIONS__options, nullptr }
+{
+  const_opts.push_back ({ LV2_OPTIONS_INSTANCE, 0, plugin_host.urids.param_sampleRate,
+                          sizeof(float), plugin_host.urids.atom_Float, &m_sample_rate });
+  const_opts.push_back ({ LV2_OPTIONS_INSTANCE, 0, plugin_host.urids.bufsz_minBlockLength,
+                          sizeof(int32_t), plugin_host.urids.atom_Int, &m_block_length });
+  const_opts.push_back ({ LV2_OPTIONS_INSTANCE, 0, plugin_host.urids.bufsz_maxBlockLength,
+                          sizeof(int32_t), plugin_host.urids.atom_Int, &m_block_length });
+  const_opts.push_back ({ LV2_OPTIONS_INSTANCE, 0, 0, 0, 0, nullptr });
+
+  lv2_options_feature.data = &const_opts[0];
+}
+
+PluginInstance *
+PluginHost::instantiate (const char *plugin_uri, float mix_freq)
+{
+  LilvNode* uri = lilv_new_uri (world, plugin_uri);
+  if (!uri)
+    {
+      fprintf (stderr, "Invalid plugin URI <%s>\n", plugin_uri);
+      return nullptr;
+    }
+
+  const LilvPlugins* plugins = lilv_world_get_all_plugins (world);
+
+  const LilvPlugin*  plugin  = lilv_plugins_get_by_uri (plugins, uri);
+
+  if (!plugin)
+    {
+      fprintf (stderr, "plugin is nil\n");
+      return nullptr;
+    }
+  lilv_node_free (uri);
+
+  LilvInstance *instance = lilv_plugin_instantiate (plugin, mix_freq, features.get_features());
+  if (!instance)
+    {
+      fprintf (stderr, "plugin instantiate failed\n");
+      exit (1);
+    }
+
+  PluginInstance *plugin_instance = new PluginInstance (*this);
+  plugin_instance->instance = instance;
+  plugin_instance->plugin = plugin;
+  plugin_instance->init_ports();
+
+  return plugin_instance;
+}
+
+void
+PluginInstance::init_ports()
+{
+  const int n_ports = lilv_plugin_get_num_ports (plugin);
+
+  // don't resize later, otherwise control connections get lost
+  plugin_ports.resize (n_ports);
+
+  vector<float> defaults (n_ports);
+
+  size_t n_control_ports = 0;
+
+  lilv_plugin_get_port_ranges_float (plugin, nullptr, nullptr, &defaults[0]);
+  for (int i = 0; i < n_ports; i++)
+    {
+      const LilvPort *port = lilv_plugin_get_port_by_index (plugin, i);
+      if (port)
+        {
+          if (lilv_port_is_a (plugin, port, plugin_host.nodes.lv2_input_class))
+            {
+              if (lilv_port_is_a (plugin, port, plugin_host.nodes.lv2_audio_class))
+                {
+                  audio_in_ports.push_back (i);
+                }
+              else if (lilv_port_is_a (plugin, port, plugin_host.nodes.lv2_atom_class))
+                {
+                  printf ("found atom input port\n");
+                  const int buf_size = 4096;
+                  plugin_ports[i].evbuf = lv2_evbuf_new (buf_size, LV2_EVBUF_ATOM, plugin_host.urid_map.urid_map (lilv_node_as_string (plugin_host.nodes.lv2_atom_Chunk)),
+                                                                                   plugin_host.urid_map.urid_map (lilv_node_as_string (plugin_host.nodes.lv2_atom_Sequence)));
+                  lilv_instance_connect_port (instance, i, lv2_evbuf_get_buffer (plugin_ports[i].evbuf));
+
+                  atom_in_ports.push_back (i);
+                }
+              else if (lilv_port_is_a (plugin, port, plugin_host.nodes.lv2_control_class))
+                {
+                  plugin_ports[i].control = defaults[i];      // start with default value
+                  plugin_ports[i].type = Port::CONTROL_IN;
+
+                  lilv_instance_connect_port (instance, i, &plugin_ports[i].control);
+
+                  n_control_ports++;
+                }
+              else
+                {
+                  printf ("found unknown input port\n");
+                }
+            }
+          if (lilv_port_is_a (plugin, port, plugin_host.nodes.lv2_output_class))
+            {
+              if (lilv_port_is_a (plugin, port, plugin_host.nodes.lv2_audio_class))
+                {
+                  audio_out_ports.push_back (i);
+                }
+              else if (lilv_port_is_a (plugin, port, plugin_host.nodes.lv2_atom_class))
+                {
+                  atom_out_ports.push_back (i);
+
+                  printf ("found atom output port\n");
+                  const int buf_size = 4096;
+                  plugin_ports[i].evbuf = lv2_evbuf_new (buf_size, LV2_EVBUF_ATOM, plugin_host.urid_map.urid_map (lilv_node_as_string (plugin_host.nodes.lv2_atom_Chunk)),
+                                                                                   plugin_host.urid_map.urid_map (lilv_node_as_string (plugin_host.nodes.lv2_atom_Sequence)));
+                  lilv_instance_connect_port (instance, i, lv2_evbuf_get_buffer (plugin_ports[i].evbuf));
+
+                }
+              else if (lilv_port_is_a (plugin, port, plugin_host.nodes.lv2_control_class))
+                {
+                  plugin_ports[i].control = defaults[i];      // start with default value
+                  plugin_ports[i].type = Port::CONTROL_OUT;
+
+                  lilv_instance_connect_port (instance, i, &plugin_ports[i].control);
+                }
+              else
+                {
+                  printf ("found unknown output port\n");
+                }
+            }
+        }
+    }
+
+  printf ("--------------------------------------------------\n");
+  printf ("audio IN:%zd OUT:%zd\n", audio_in_ports.size(), audio_out_ports.size());
+  printf ("control IN:%zd\n", n_control_ports);
+  printf ("--------------------------------------------------\n");
+}
+
+void
+PluginInstance::write_midi (uint32_t time, size_t size, const uint8_t *data)
+{
+  if (!atom_in_ports.empty())
+    {
+      /* we use the first atom in port for midi, is there a better strategy? */
+      int p = atom_in_ports[0];
+
+      LV2_Evbuf           *evbuf = plugin_ports[p].evbuf;
+      LV2_Evbuf_Iterator    iter = lv2_evbuf_end (evbuf);
+
+      lv2_evbuf_write (&iter, time, 0, plugin_host.urids.midi_MidiEvent, size, data);
+    }
+}
+
+void
+PluginInstance::reset_event_buffers()
+{
+  for (int p : atom_out_ports)
+    {
+      /* Clear event output for plugin to write to */
+      LV2_Evbuf *evbuf = plugin_ports[p].evbuf;
+
+      lv2_evbuf_reset (evbuf, false);
+    }
+  for (int p : atom_in_ports)
+    {
+      LV2_Evbuf *evbuf = plugin_ports[p].evbuf;
+
+      lv2_evbuf_reset (evbuf, true);
+    }
+}
+
+void
+PluginInstance::run (float *audio_out_l, float *audio_out_r, uint32_t nframes)
+{
+  float fake_in[nframes];
+
+  // fake input: use on-stack buffer with zeros
+  if (!audio_in_ports.empty())
+    {
+      std::fill_n (fake_in, nframes, 0.0);
+
+      for (size_t i = 0; i < audio_in_ports.size(); i++)
+        lilv_instance_connect_port (instance, audio_in_ports[i], fake_in);
+    }
+  const bool mono_plugin = audio_out_ports.size() == 1;
+  const bool stereo_plugin = audio_out_ports.size() == 2;
+
+  assert_return (mono_plugin || stereo_plugin);
+  lilv_instance_connect_port (instance, audio_out_ports[0], audio_out_l);
+
+  if (stereo_plugin)
+    lilv_instance_connect_port (instance, audio_out_ports[1], audio_out_r);
+
+  assert_return (atom_in_ports.size() == 1);
+
+  lilv_instance_run (instance, nframes);
+
+  // automatically convert mono -> stereo
+  if (mono_plugin)
+    std::copy (audio_out_l, audio_out_l + nframes, audio_out_r);
+}
+
+}
+
+class LV2Device : public AudioSignal::Processor {
+  OBusId stereo_out_;
+  PluginInstance *plugin_instance;
+  PluginHost plugin_host; // TODO: should be only one instance for all lv2 devices
+
+  static constexpr const int PID_CC_OFFSET = 1000;
+  void
+  initialize () override
+  {
+    plugin_host.options.set (sample_rate(), /* FIXME: buffer size */ 128);
+    plugin_instance = plugin_host.instantiate ("http://zynaddsubfx.sourceforge.net", sample_rate());
+  }
+  void
+  query_info (ProcessorInfo &info) const override
+  {
+    info.uri = "Bse.LV2Device";
+    // info.version = "0";
+    info.label = "LV2Device";
+    info.category = "Synth";
+  }
+  void
+  configure (uint n_ibusses, const SpeakerArrangement *ibusses, uint n_obusses, const SpeakerArrangement *obusses) override
+  {
+    remove_all_buses();
+    prepare_event_input();
+    stereo_out_ = add_output_bus ("Stereo Out", SpeakerArrangement::STEREO);
+    assert_return (bus_info (stereo_out_).ident == "stereo-out");
+  }
+  void
+  reset () override
+  {
+    adjust_params (true);
+  }
+  void
+  adjust_param (Id32 tag) override
+  {
+    // TODO
+  }
+  void
+  render (uint n_frames) override
+  {
+    adjust_params (false);
+
+    // reset event buffers and write midi events
+    plugin_instance->reset_event_buffers();
+    EventRange erange = get_event_input();
+
+    for (const auto &ev : erange)
+      {
+        const int time_stamp = std::max<int> (ev.frame, 0);
+        uint8_t midi_data[3] = { 0, };
+
+        switch (ev.message())
+          {
+          case Message::NOTE_OFF:
+            midi_data[0] = 0x80 | ev.channel;
+            midi_data[1] = ev.key;
+            plugin_instance->write_midi (time_stamp, 3, midi_data);
+            break;
+          case Message::NOTE_ON:
+            midi_data[0] = 0x90 | ev.channel;
+            midi_data[1] = ev.key;
+            midi_data[2] = std::clamp (bse_ftoi (ev.velocity * 127), 0, 127);
+            plugin_instance->write_midi (time_stamp, 3, midi_data);
+            break;
+#if 0
+          case Message::ALL_NOTES_OFF:
+          case Message::ALL_SOUND_OFF:
+            synth_.all_sound_off();    // NOTE: there is no extra "all notes off" in liquidsfz
+            break;
+#endif
+          default: ;
+          }
+      }
+
+    float *output[2] = {
+      oblock (stereo_out_, 0),
+      oblock (stereo_out_, 1)
+    };
+    plugin_instance->run (output[0], output[1], n_frames);
+  }
+};
+
+static auto lv2device = Bse::enroll_asp<LV2Device>();
+
+} // Bse

--- a/devices/lv2device/lv2device.cc
+++ b/devices/lv2device/lv2device.cc
@@ -470,7 +470,10 @@ class LV2Device : public AudioSignal::Processor {
   initialize () override
   {
     plugin_host.options.set (sample_rate(), /* FIXME: buffer size */ 128);
-    plugin_instance = plugin_host.instantiate ("http://zynaddsubfx.sourceforge.net", sample_rate());
+    const char *uri = getenv ("LV2URI");
+    if (!uri)
+      uri = "http://zynaddsubfx.sourceforge.net";
+    plugin_instance = plugin_host.instantiate (uri, sample_rate());
   }
   void
   query_info (ProcessorInfo &info) const override

--- a/devices/lv2device/lv2device.cc
+++ b/devices/lv2device/lv2device.cc
@@ -692,11 +692,14 @@ class LV2Device : public AudioSignal::Processor {
       uri = "http://zynaddsubfx.sourceforge.net";
     plugin_instance = plugin_host.instantiate (uri, sample_rate());
 
-    ChoiceEntries centries;
-    centries += { "-none-" };
-    for (auto preset : plugin_instance->presets)
-      centries += { preset.name };
-    add_param (PID_PRESET, "Device Preset", "Preset", std::move (centries), 0, "", "Device Preset to be used");
+    if (plugin_instance->presets.size()) /* choice with 1 entry will crash */
+      {
+        ChoiceEntries centries;
+        centries += { "-none-" };
+        for (auto preset : plugin_instance->presets)
+          centries += { preset.name };
+        add_param (PID_PRESET, "Device Preset", "Preset", std::move (centries), 0, "", "Device Preset to be used");
+      }
     current_preset = 0;
 
     add_param (PID_DELETE, "Test Delete", "TestDel", false);

--- a/devices/lv2device/lv2device.cc
+++ b/devices/lv2device/lv2device.cc
@@ -34,6 +34,7 @@ class Map
 {
   LV2_URID              next_id;
   map<string, LV2_URID> m_urid_map;
+  map<LV2_URID, String> m_urid_unmap;
 
   LV2_URID_Map       lv2_urid_map;
   const LV2_Feature  lv2_urid_map_feature;
@@ -58,8 +59,18 @@ public:
     if (id == 0)
       id = next_id++;
 
+    m_urid_unmap[id] = str;
     printf ("map %s -> %d\n", str, id);
     return id;
+  }
+  const char *
+  urid_unmap (LV2_URID id)
+  {
+    auto it = m_urid_unmap.find (id);
+    if (it != m_urid_unmap.end())
+      return it->second.c_str();
+    else
+      return nullptr;
   }
 
   const LV2_Feature *
@@ -697,11 +708,8 @@ class LV2Device : public AudioSignal::Processor {
       }
     else
       {
-        // TODO: unmap
-#if 0
-                fprintf(stderr, "error: Preset `%s' value has bad type <%s>\n",
-                        port_symbol, jalv->unmap.unmap(jalv->unmap.handle, type));
-#endif
+        fprintf (stderr, "error: Preset `%s' value has bad type <%s>\n",
+                          port_symbol, plugin_instance->plugin_host.urid_map.urid_unmap (type));
         return;
       }
     printf ("%s = %f\n", port_symbol, dvalue);

--- a/devices/lv2device/lv2device.cc
+++ b/devices/lv2device/lv2device.cc
@@ -731,6 +731,8 @@ class LV2Device : public AudioSignal::Processor {
     for (auto& port : plugin_instance->plugin_ports)
       if (port.type == Port::CONTROL_IN)
         {
+          // TODO: lv2 port numbers are not reliable for serialization, should use port.symbol instead
+          // TODO: special case boolean, enumeration, logarithmic,... controls
           add_param (pid++, port.name, port.name, port.min_value, port.max_value, port.control);
           param_id_port.push_back (&port);
         }

--- a/devices/lv2device/lv2device.cc
+++ b/devices/lv2device/lv2device.cc
@@ -323,6 +323,7 @@ struct PluginInstance
   std::vector<int>              audio_in_ports;
   std::vector<int>              audio_out_ports;
   std::vector<PresetInfo>       presets;
+  bool                          active = false;
 
   void init_ports();
   void init_presets();
@@ -472,6 +473,9 @@ PluginInstance::PluginInstance (PluginHost& plugin_host) :
 PluginInstance::~PluginInstance()
 {
   worker.stop();
+
+  if (active)
+    deactivate();
 }
 
 void
@@ -626,13 +630,25 @@ PluginInstance::reset_event_buffers()
 void
 PluginInstance::activate()
 {
-  lilv_instance_activate (instance);
+  if (!active)
+    {
+      printf ("activate\n");
+      lilv_instance_activate (instance);
+
+      active = true;
+    }
 }
 
 void
 PluginInstance::deactivate()
 {
-  lilv_instance_deactivate (instance);
+  if (active)
+    {
+      printf ("deactivate\n");
+      lilv_instance_deactivate (instance);
+
+      active = false;
+    }
 }
 
 void

--- a/devices/lv2device/lv2device.cc
+++ b/devices/lv2device/lv2device.cc
@@ -189,6 +189,8 @@ struct PluginInstance
   void reset_event_buffers();
   void write_midi (uint32_t time, size_t size, const uint8_t *data);
   void run (float *audio_out_l, float *audio_out_r, uint32_t nframes);
+  void activate();
+  void deactivate();
 };
 
 struct PluginHost
@@ -440,6 +442,18 @@ PluginInstance::reset_event_buffers()
 }
 
 void
+PluginInstance::activate()
+{
+  lilv_instance_activate (instance);
+}
+
+void
+PluginInstance::deactivate()
+{
+  lilv_instance_deactivate (instance);
+}
+
+void
 PluginInstance::run (float *audio_out_l, float *audio_out_r, uint32_t nframes)
 {
   float fake_in[nframes];
@@ -495,6 +509,10 @@ class LV2Device : public AudioSignal::Processor {
           add_param (port.name, port.name, port.min_value, port.max_value, port.control);
           param_id_port.push_back (&port);
         }
+
+    // TODO: deactivate?
+    // TODO: is this the right place?
+    plugin_instance->activate();
   }
   void
   query_info (ProcessorInfo &info) const override

--- a/devices/lv2device/lv2device.cc
+++ b/devices/lv2device/lv2device.cc
@@ -225,6 +225,13 @@ public:
         worker_interface->work_response (instance, size, data);
       }
   }
+  void
+  end_run()
+  {
+    /* to be called after each run cycle */
+    if (worker_interface && worker_interface->end_run)
+      worker_interface->end_run (instance);
+  }
   static LV2_Worker_Status
   schedule (LV2_Worker_Schedule_Handle handle,
             uint32_t                   size,
@@ -670,6 +677,9 @@ void
 PluginInstance::run (uint32_t nframes)
 {
   lilv_instance_run (instance, nframes);
+
+  worker.handle_responses();
+  worker.end_run();
 }
 
 }
@@ -897,7 +907,6 @@ class LV2Device : public AudioSignal::Processor {
           plugin_instance->connect_audio_port (plugin_instance->audio_out_ports[i], oblock (mono_outs_[i], 0));
       }
     plugin_instance->run (n_frames);
-    plugin_instance->worker.handle_responses();
   }
   void
   set_port_value (const char*         port_symbol,

--- a/devices/lv2device/ringbuffer.hh
+++ b/devices/lv2device/ringbuffer.hh
@@ -1,0 +1,266 @@
+// Licensed GNU LGPL v2.1 or later: http://www.gnu.org/licenses/lgpl.html
+
+#include "bse/bseblockutils.hh"
+
+namespace {
+
+using namespace Bse;
+using namespace std;
+
+/**
+ * This function uses std::copy to copy the n_values of data from ivalues
+ * to ovalues. If a specialized version is available in bseblockutils,
+ * then this - usually faster - version will be used.
+ *
+ * The data in ivalues and ovalues may not overlap.
+ */
+template<class Data> void
+fast_copy (uint        n_values,
+           Data       *ovalues,
+	   const Data *ivalues)
+{
+  copy (ivalues, ivalues + n_values, ovalues);
+}
+
+template<> void
+fast_copy (uint         n_values,
+           float       *ovalues,
+           const float *ivalues)
+{
+  Block::copy (n_values, ovalues, ivalues);
+}
+
+template<> BSE_UNUSED void
+fast_copy (uint	         n_values,
+           uint32       *ovalues,
+           const uint32 *ivalues)
+{
+  Block::copy (n_values, ovalues, ivalues);
+}
+
+/**
+ * The FrameRingBuffer class implements a ringbuffer for the communication
+ * between two threads. One thread - the producer thread - may only write
+ * data to the ringbuffer. The other thread - the consumer thread - may
+ * only read data from the ringbuffer.
+ *
+ * Given that these two threads only use the appropriate functions, no
+ * other synchronization is required to ensure that the data gets safely
+ * from the producer thread to the consumer thread. However, all operations
+ * that are provided by the ringbuffer are non-blocking, so that you may
+ * need a condition or other synchronization primitive if you want the
+ * producer and/or consumer to block if the ringbuffer is full/empty.
+ *
+ * Implementation: the synchronization between the two threads is only
+ * implemented by two index variables (read_frame_pos and write_frame_pos)
+ * for which atomic integer reads and writes are required. Since the
+ * producer thread only modifies the write_frame_pos and the consumer thread
+ * only modifies the read_frame_pos, no compare-and-swap or similar
+ * operations are needed to avoid concurrent writes.
+ */
+template<class T>
+class FrameRingBuffer {
+  //BIRNET_PRIVATE_COPY (FrameRingBuffer);
+private:
+  vector<vector<T> >  channel_buffer_;
+  std::atomic<int>    atomic_read_frame_pos_ {0};
+  std::atomic<int>    atomic_write_frame_pos_ {0};
+  uint                channel_buffer_size_ = 0;       // = n_frames + 1; the extra frame allows us to
+                                                      // see the difference between an empty/full ringbuffer
+  uint                n_channels_ = 0;
+public:
+  FrameRingBuffer (uint n_frames = 0,
+		   uint n_channels = 1)
+  {
+    resize (n_frames, n_channels);
+  }
+  /**
+   * Check available read space in the ringbuffer.
+   * This function may only be called from the consumer thread.
+   *
+   * @returns the number of frames that are available for reading
+   */
+  uint
+  get_readable_frames()
+  {
+    int wpos = atomic_write_frame_pos_;
+    int rpos = atomic_read_frame_pos_;
+
+    if (wpos < rpos)		    /* wpos == rpos -> empty ringbuffer */
+      wpos += channel_buffer_size_;
+
+    return wpos - rpos;
+  }
+  /**
+   * Read data from the ringbuffer; if there is not enough data
+   * in the ringbuffer, the function will return the number of frames
+   * that could be read without blocking.
+   *
+   * This function should be called from the consumer thread.
+   *
+   * @returns the number of successfully read frames
+   */
+  uint
+  read (uint    n_frames,
+        T     **frames)
+  {
+    int rpos = atomic_read_frame_pos_;
+    uint can_read = std::min (get_readable_frames(), n_frames);
+
+    uint read1 = std::min (can_read, channel_buffer_size_ - rpos);
+    uint read2 = can_read - read1;
+
+    for (uint ch = 0; ch < n_channels_; ch++)
+      {
+	fast_copy (read1, frames[ch], &channel_buffer_[ch][rpos]);
+	fast_copy (read2, frames[ch] + read1, &channel_buffer_[ch][0]);
+      }
+
+    atomic_read_frame_pos_ = (rpos + can_read) % channel_buffer_size_;
+    return can_read;
+  }
+  /**
+   * Check available write space in the ringbuffer.
+   * This function should be called from the producer thread.
+   *
+   * @returns the number of frames that can be written
+   */
+  uint
+  get_writable_frames()
+  {
+    int wpos = atomic_write_frame_pos_;
+    int rpos = atomic_read_frame_pos_;
+
+    if (rpos <= wpos)		    /* wpos == rpos -> empty ringbuffer */
+      rpos += channel_buffer_size_;
+
+    // the extra frame allows us to see the difference between an empty/full ringbuffer
+    return rpos - wpos - 1;
+  }
+  /**
+   * Write data to the ringbuffer; if there is not enough free space
+   * in the ringbuffer, the function will return the amount of frames
+   * consumed by a partial write (without blocking).
+   *
+   * This function may only be called from the producer thread.
+   *
+   * @returns the number of successfully written frames
+   */
+  uint
+  write (uint      n_frames,
+         const T **frames)
+  {
+    int wpos = atomic_write_frame_pos_;
+    uint can_write = std::min (get_writable_frames(), n_frames);
+
+    uint write1 = std::min (can_write, channel_buffer_size_ - wpos);
+    uint write2 = can_write - write1;
+
+    for (uint ch = 0; ch < n_channels_; ch++)
+      {
+	fast_copy (write1, &channel_buffer_[ch][wpos], frames[ch]);
+	fast_copy (write2, &channel_buffer_[ch][0], frames[ch] + write1);
+      }
+
+    // It is important that the data from the previous writes get written
+    // to memory *before* the index variable is updated.
+    //
+    // Writing the C++ atomic variable (position) as last step should ensure
+    // correct ordering (also across threads).
+
+    atomic_write_frame_pos_ = (wpos + can_write) % channel_buffer_size_;
+    return can_write;
+  }
+  /**
+   * Get total size of the ringbuffer.
+   * This function can be called from any thread.
+   *
+   * @returns the maximum number of frames that the ringbuffer can contain
+   */
+  uint
+  get_total_n_frames() const
+  {
+    // the extra frame allows us to see the difference between an empty/full ringbuffer
+    return channel_buffer_size_ - 1;
+  }
+  /**
+   * Get number of channels.
+   * This function can be called from any thread.
+   *
+   * @returns the number of elements that are part of one frame
+   */
+  uint
+  get_n_channels() const
+  {
+    return n_channels_;
+  }
+  /**
+   * Clear the ringbuffer.
+   *
+   * This function may not be used while either the producer thread or
+   * the consumer thread are modifying the ringbuffer.
+   */
+  void
+  clear()
+  {
+    atomic_read_frame_pos_ = 0;
+    atomic_write_frame_pos_ = 0;
+  }
+  /**
+   * Resize and clear the ringbuffer.
+   *
+   * This function may not be used while either the producer thread or
+   * the consumer thread are modifying the ringbuffer.
+   */
+  void
+  resize (uint n_frames,
+          uint n_channels = 1)
+  {
+    n_channels_ = n_channels;
+    channel_buffer_.resize (n_channels);
+
+    // the extra frame allows us to see the difference between an empty/full ringbuffer
+    channel_buffer_size_ = n_frames + 1;
+    for (uint ch = 0; ch < n_channels_; ch++)
+      channel_buffer_[ch].resize (channel_buffer_size_);
+
+    clear();
+  }
+};
+
+template<class T>
+class RingBuffer
+{
+  FrameRingBuffer<T> buffer_;
+public:
+  RingBuffer (uint n_values = 0) :
+    buffer_ (n_values)
+  {
+  }
+  uint
+  write (uint     n_values,
+         const T *values)
+  {
+    const T *t[1] = { values };
+    return buffer_.write (n_values, t);
+  }
+  uint
+  get_writable_values()
+  {
+    return buffer_.get_writable_frames();
+  }
+  uint
+  read (uint n_values,
+        T   *values)
+  {
+    T *t[1] = { values };
+    return buffer_.read (n_values, t);
+  }
+  uint
+  get_readable_values()
+  {
+    return buffer_.get_readable_frames();
+  }
+};
+
+};


### PR DESCRIPTION
I've been working on LV2 support. This is work in progress, so I'm submitting the current version here, while I know the code is somewhat incomplete. As discussed previously, there is no custom UI support yet, and should be added once we have out-of-process support.

- the ringbuffer is a copy from jack driver, so probably we should have Bse::FrameRingBuffer<T> and Bse::RingBuffer<T> implemented in bse/ringbuffer.hh and used by both
- the code is used by specifying at LV2 URI (defaults to zynaddsubfx), like
```
LV2URI=http://synthv1.sourceforge.net/lv2 make run # synth
LV2URI=http://calf.sourceforge.net/plugins/Monosynth make run # synth
LV2URI=urn:ardour:a-reverb make run # stereo effect
```
- preset loading should not be done in RT thread (as discussed in last meeting), and notify UI, too
- there should be a way to select which plugin to use (LV2URI) other than commandline